### PR TITLE
Add MCP build-host tools for the running Rush watch (rush-serve)

### DIFF
--- a/apps/rush-mcp-server/package.json
+++ b/apps/rush-mcp-server/package.json
@@ -59,6 +59,7 @@
     "@rushstack/rush-sdk": "workspace:*",
     "@rushstack/ts-command-line": "workspace:*",
     "@modelcontextprotocol/sdk": "~1.10.2",
+    "ws": "~8.20.0",
     "zod": "~3.25.76"
   },
   "devDependencies": {
@@ -66,7 +67,8 @@
     "eslint": "~9.37.0",
     "local-node-rig": "workspace:*",
     "typescript": "~5.8.2",
-    "@types/node": "20.17.19"
+    "@types/node": "20.17.19",
+    "@types/ws": "8.5.5"
   },
   "sideEffects": [
     "lib-commonjs/start.js",

--- a/apps/rush-mcp-server/package.json
+++ b/apps/rush-mcp-server/package.json
@@ -72,6 +72,8 @@
   },
   "sideEffects": [
     "lib-commonjs/start.js",
-    "lib-esm/start.js"
+    "lib-esm/start.js",
+    "lib-commonjs/daemon/start.js",
+    "lib-esm/daemon/start.js"
   ]
 }

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -7,7 +7,7 @@ import { spawn, type ChildProcess } from 'node:child_process';
 
 import { WebSocket, type RawData } from 'ws';
 
-import { Executable } from '@rushstack/node-core-library';
+import { Executable, SubprocessTerminator } from '@rushstack/node-core-library';
 
 import type {
   IOperationInfo,
@@ -109,7 +109,6 @@ export class RushServeClient {
   private _webSocket: WebSocket | undefined;
   private _readyPromise: Promise<void> | undefined;
   private _spawnedChild: ChildProcess | undefined;
-  private _cleanupRegistered: boolean;
 
   private _overallStatus: ReadableOperationStatus;
   private _sessionInfo: IRushSessionInfo | undefined;
@@ -126,7 +125,6 @@ export class RushServeClient {
     this._httpsOrigin = toHttpsOrigin(this._configuredWebSocketUrl);
     this._httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
-    this._cleanupRegistered = false;
     this._overallStatus = 'Ready';
     this._operationsByName = new Map();
   }
@@ -336,13 +334,14 @@ export class RushServeClient {
 
     const child: ChildProcess = spawn(resolvedCommand, this._startArgs, {
       cwd: this._workspacePath,
-      // Run in its own process group so we can terminate the whole tree later.
-      detached: true,
+      // detached (on POSIX) lets SubprocessTerminator terminate the whole process tree.
+      ...SubprocessTerminator.RECOMMENDED_OPTIONS,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: childEnv
     });
     this._spawnedChild = child;
-    this._registerHostCleanup();
+    // Terminate the host (and its descendants) if this process exits or is signalled.
+    SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
 
     // The path of the WebSocket endpoint comes from the configured URL; the host:port is discovered.
     const webSocketPath: string = new URL(this._configuredWebSocketUrl).pathname;
@@ -399,31 +398,13 @@ export class RushServeClient {
     });
   }
 
-  private _registerHostCleanup(): void {
-    if (this._cleanupRegistered) {
-      return;
-    }
-    this._cleanupRegistered = true;
-    process.once('exit', () => this._killSpawnedHost());
-    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-      process.once(signal, () => {
-        this._killSpawnedHost();
-        process.exit(signal === 'SIGINT' ? 130 : 143);
-      });
-    }
-  }
-
   private _killSpawnedHost(): void {
     const child: ChildProcess | undefined = this._spawnedChild;
-    if (!child || child.exitCode !== null || child.pid === undefined) {
+    if (!child) {
       return;
     }
-    try {
-      // Negative pid targets the whole process group (the host was started detached).
-      process.kill(-child.pid, 'SIGTERM');
-    } catch {
-      // Best effort; ignore (the process may have already exited).
-    }
+    // Terminates the entire process tree (SIGKILL of the group on POSIX, TaskKill /T on Windows).
+    SubprocessTerminator.killProcessTree(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
   }
 
   private _handleMessage(message: IWebSocketEventMessage): void {

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -3,8 +3,11 @@
 
 import * as https from 'node:https';
 import type { ClientRequest, IncomingMessage } from 'node:http';
+import { spawn, type ChildProcess } from 'node:child_process';
 
 import { WebSocket, type RawData } from 'ws';
+
+import { Executable } from '@rushstack/node-core-library';
 
 import type {
   IOperationInfo,
@@ -16,12 +19,19 @@ import type {
 
 /**
  * The default WebSocket URL for the build status server. Override with the
- * `RUSH_BUILD_STATUS_WS_URL` environment variable to match the `buildStatusWebSocketPath`
+ * `RUSHMCP_BUILD_STATUS_WS_URL` environment variable to match the `buildStatusWebSocketPath`
  * and port configured for `@rushstack/rush-serve-plugin`.
  */
 const DEFAULT_WEB_SOCKET_URL: string = 'wss://localhost:8443/';
 
+/** Default command used to start a build host when none is reachable. */
+const DEFAULT_START_COMMAND: string = 'rush start';
+
 const CONNECT_TIMEOUT_MS: number = 15000;
+const DEFAULT_START_TIMEOUT_MS: number = 180000;
+
+/** Matches the `https://<host>:<port>/` line that rush-serve logs once it begins serving. */
+const SERVE_URL_REGEX: RegExp = /https:\/\/([a-zA-Z0-9.-]+):(\d+)\//;
 
 /**
  * A point-in-time view of the build host's state.
@@ -36,69 +46,112 @@ export interface IBuildStatusSnapshot {
 export interface IRushServeClientOptions {
   /** The full WebSocket URL of the build status server, e.g. `wss://localhost:8443/`. */
   webSocketUrl: string;
+  /** If true, start a build host (`rush start`) when none is reachable. Default true. */
+  autoStart: boolean;
+  /** The executable to start a build host with, e.g. `rush`. */
+  startCommand: string;
+  /** The arguments for the start command, e.g. `["start"]`. */
+  startArgs: string[];
+  /** The working directory in which to start the build host (the Rush workspace root). */
+  workspacePath: string;
+  /** How long to wait for a spawned build host to begin serving before giving up. */
+  startTimeoutMs: number;
 }
 
 /**
  * Resolves the build host connection options from the environment.
  */
-export function getBuildHostConfigFromEnv(): IRushServeClientOptions {
-  // eslint-disable-next-line dot-notation
-  const webSocketUrl: string = process.env['RUSH_BUILD_STATUS_WS_URL'] || DEFAULT_WEB_SOCKET_URL;
-  return { webSocketUrl };
+export function getBuildHostConfigFromEnv(workspacePath: string): IRushServeClientOptions {
+  /* eslint-disable dot-notation */
+  const env: NodeJS.ProcessEnv = process.env;
+  const webSocketUrl: string = env['RUSHMCP_BUILD_STATUS_WS_URL'] || DEFAULT_WEB_SOCKET_URL;
+  const autoStartRaw: string | undefined = env['RUSHMCP_BUILD_AUTOSTART'];
+  const autoStart: boolean = autoStartRaw === undefined ? true : !/^(0|false|no)$/i.test(autoStartRaw);
+  const startCommandRaw: string = env['RUSHMCP_BUILD_START_COMMAND'] || DEFAULT_START_COMMAND;
+  const startTimeoutMs: number = Number(env['RUSHMCP_BUILD_START_TIMEOUT_MS']) || DEFAULT_START_TIMEOUT_MS;
+  /* eslint-enable dot-notation */
+
+  const startParts: string[] = startCommandRaw.trim().split(/\s+/);
+  return {
+    webSocketUrl,
+    autoStart,
+    startCommand: startParts[0],
+    startArgs: startParts.slice(1),
+    workspacePath,
+    startTimeoutMs
+  };
+}
+
+function toHttpsOrigin(wsUrl: string): string {
+  const url: URL = new URL(wsUrl);
+  url.protocol = url.protocol === 'wss:' ? 'https:' : 'http:';
+  return url.origin;
 }
 
 /**
- * A client that connects to the live build status WebSocket served by `@rushstack/rush-serve-plugin`
- * (typically from a running `rush start`), maintains an in-memory snapshot of the build graph, and
- * fetches per-operation logs over HTTPS.
- *
- * The connection is established lazily on first use, so constructing this client is free and does not
- * require a running build host.
+ * A client that connects to the live build status WebSocket served by `@rushstack/rush-serve-plugin`.
+ * If no host is reachable and `autoStart` is enabled, it starts one (`rush start`), discovers the
+ * port it serves on, and connects. The connection is established lazily on first use.
  */
 export class RushServeClient {
-  private readonly _webSocketUrl: string;
-  private readonly _httpsOrigin: string;
+  private readonly _configuredWebSocketUrl: string;
+  private readonly _autoStart: boolean;
+  private readonly _startCommand: string;
+  private readonly _startArgs: string[];
+  private readonly _workspacePath: string;
+  private readonly _startTimeoutMs: number;
   // The serve plugin uses a self-signed debug certificate. For localhost dev tooling we skip
   // verification.
   // TODO (hardening): trust the CA via @rushstack/debug-certificate-manager instead of disabling it.
   private readonly _httpsAgent: https.Agent;
 
+  private _httpsOrigin: string;
   private _webSocket: WebSocket | undefined;
   private _readyPromise: Promise<void> | undefined;
+  private _spawnedChild: ChildProcess | undefined;
+  private _cleanupRegistered: boolean;
 
   private _overallStatus: ReadableOperationStatus;
   private _sessionInfo: IRushSessionInfo | undefined;
   private readonly _operationsByName: Map<string, IOperationInfo>;
 
   public constructor(options: IRushServeClientOptions) {
-    this._webSocketUrl = options.webSocketUrl;
+    this._configuredWebSocketUrl = options.webSocketUrl;
+    this._autoStart = options.autoStart;
+    this._startCommand = options.startCommand;
+    this._startArgs = options.startArgs;
+    this._workspacePath = options.workspacePath;
+    this._startTimeoutMs = options.startTimeoutMs;
 
-    const httpsUrl: URL = new URL(this._webSocketUrl);
-    httpsUrl.protocol = httpsUrl.protocol === 'wss:' ? 'https:' : 'http:';
-    this._httpsOrigin = httpsUrl.origin;
-
+    this._httpsOrigin = toHttpsOrigin(this._configuredWebSocketUrl);
     this._httpsAgent = new https.Agent({ rejectUnauthorized: false });
 
+    this._cleanupRegistered = false;
     this._overallStatus = 'Ready';
     this._operationsByName = new Map();
   }
 
   public get webSocketUrl(): string {
-    return this._webSocketUrl;
+    return this._configuredWebSocketUrl;
   }
 
   /**
-   * Ensures the client is connected and has received an initial snapshot. Safe to call repeatedly;
-   * it will reconnect if a previous connection was closed.
+   * Ensures the client is connected and has received an initial snapshot. If no host is reachable and
+   * autostart is enabled, starts one first. Safe to call repeatedly.
    */
   public async ensureReadyAsync(): Promise<void> {
     if (this._webSocket && this._webSocket.readyState === WebSocket.OPEN) {
       return;
     }
     if (!this._readyPromise) {
-      this._readyPromise = this._connectAsync();
+      this._readyPromise = this._establishConnectionAsync();
     }
-    await this._readyPromise;
+    try {
+      await this._readyPromise;
+    } catch (error) {
+      this._readyPromise = undefined;
+      throw error;
+    }
   }
 
   /**
@@ -178,17 +231,44 @@ export class RushServeClient {
     });
   }
 
-  private async _connectAsync(): Promise<void> {
+  /**
+   * Terminates a build host that this client started (if any). No-op if the host was not started by us.
+   */
+  public disposeAsync(): void {
+    this._killSpawnedHost();
+  }
+
+  private async _establishConnectionAsync(): Promise<void> {
+    // 1. Try to connect to an already-running host.
+    try {
+      await this._connectToUrlAsync(this._configuredWebSocketUrl);
+      return;
+    } catch (initialError) {
+      if (!this._autoStart) {
+        throw new Error(
+          `Could not connect to the Rush build host at ${this._configuredWebSocketUrl}: ` +
+            `${(initialError as Error).message}\n` +
+            `Start one with "${this._startCommand} ${this._startArgs.join(' ')}" (with ` +
+            `@rushstack/rush-serve-plugin enabled), or enable autostart (RUSHMCP_BUILD_AUTOSTART=1).`
+        );
+      }
+    }
+
+    // 2. Nothing reachable: start a host and connect to it.
+    const startedUrl: string = await this._spawnHostAndGetUrlAsync();
+    await this._connectToUrlAsync(startedUrl);
+  }
+
+  private async _connectToUrlAsync(url: string): Promise<void> {
     return await new Promise<void>((resolve, reject) => {
-      const webSocket: WebSocket = new WebSocket(this._webSocketUrl, { rejectUnauthorized: false });
+      const webSocket: WebSocket = new WebSocket(url, { rejectUnauthorized: false });
       let settled: boolean = false;
 
       const timeout: NodeJS.Timeout = setTimeout(() => {
         if (!settled) {
           settled = true;
-          this._readyPromise = undefined;
           webSocket.terminate();
-          reject(new Error(`Timed out connecting to the Rush build host at ${this._webSocketUrl}.`));
+          reject(new Error(`Timed out connecting to ${url}.`));
         }
       }, CONNECT_TIMEOUT_MS);
 
@@ -197,7 +277,6 @@ export class RushServeClient {
         try {
           message = JSON.parse(data.toString());
         } catch {
-          // Ignore malformed messages.
           return;
         }
         this._handleMessage(message);
@@ -207,6 +286,12 @@ export class RushServeClient {
           settled = true;
           clearTimeout(timeout);
           this._webSocket = webSocket;
+          this._httpsOrigin = toHttpsOrigin(url);
+          // Reconnect on a future close.
+          webSocket.on('close', () => {
+            this._webSocket = undefined;
+            this._readyPromise = undefined;
+          });
           resolve();
         }
       });
@@ -215,23 +300,130 @@ export class RushServeClient {
         if (!settled) {
           settled = true;
           clearTimeout(timeout);
-          this._readyPromise = undefined;
-          reject(
-            new Error(
-              `Could not connect to the Rush build host at ${this._webSocketUrl}: ${error.message}\n` +
-                `Is "rush start" (or another watch command) running with @rushstack/rush-serve-plugin and a ` +
-                `matching "buildStatusWebSocketPath"? You can override the URL with the ` +
-                `RUSH_BUILD_STATUS_WS_URL environment variable.`
-            )
-          );
+          reject(error);
         }
       });
 
       webSocket.on('close', () => {
-        this._webSocket = undefined;
-        this._readyPromise = undefined;
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error('Connection closed before the initial sync message.'));
+        }
       });
     });
+  }
+
+  /**
+   * Starts a build host and resolves with the WebSocket URL it serves on (discovered by scraping the
+   * serve URL it prints to stdout).
+   */
+  private async _spawnHostAndGetUrlAsync(): Promise<string> {
+    const resolvedCommand: string | undefined = Executable.tryResolve(this._startCommand);
+    if (!resolvedCommand) {
+      throw new Error(`Cannot start a build host: command "${this._startCommand}" was not found on PATH.`);
+    }
+
+    // Strip our own config vars from the child's environment so they can't confuse Rush. (Rush also
+    // rejects any unrecognized variable that starts with the reserved "RUSH_" prefix, which is why
+    // these are named "RUSHMCP_" rather than "RUSH_".)
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) {
+      if (key.startsWith('RUSHMCP_')) {
+        delete childEnv[key];
+      }
+    }
+
+    const child: ChildProcess = spawn(resolvedCommand, this._startArgs, {
+      cwd: this._workspacePath,
+      // Run in its own process group so we can terminate the whole tree later.
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv
+    });
+    this._spawnedChild = child;
+    this._registerHostCleanup();
+
+    // The path of the WebSocket endpoint comes from the configured URL; the host:port is discovered.
+    const webSocketPath: string = new URL(this._configuredWebSocketUrl).pathname;
+
+    return await new Promise<string>((resolve, reject) => {
+      let settled: boolean = false;
+      let buffer: string = '';
+
+      const timeout: NodeJS.Timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          this._killSpawnedHost();
+          reject(
+            new Error(
+              `Timed out after ${this._startTimeoutMs}ms waiting for "${this._startCommand} ` +
+                `${this._startArgs.join(' ')}" to begin serving.`
+            )
+          );
+        }
+      }, this._startTimeoutMs);
+
+      const onData = (chunk: Buffer): void => {
+        // Keep consuming output even after we've found the URL so the child's pipe never blocks.
+        if (settled) {
+          return;
+        }
+        buffer += chunk.toString();
+        const match: RegExpMatchArray | null = buffer.match(SERVE_URL_REGEX);
+        if (match) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve(`wss://${match[1]}:${match[2]}${webSocketPath}`);
+        }
+      };
+
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+
+      child.on('error', (error: Error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error(`Failed to start build host: ${error.message}`));
+        }
+      });
+
+      child.on('exit', (code: number | null) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error(`Build host exited (code ${code}) before it began serving.`));
+        }
+      });
+    });
+  }
+
+  private _registerHostCleanup(): void {
+    if (this._cleanupRegistered) {
+      return;
+    }
+    this._cleanupRegistered = true;
+    process.once('exit', () => this._killSpawnedHost());
+    for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+      process.once(signal, () => {
+        this._killSpawnedHost();
+        process.exit(signal === 'SIGINT' ? 130 : 143);
+      });
+    }
+  }
+
+  private _killSpawnedHost(): void {
+    const child: ChildProcess | undefined = this._spawnedChild;
+    if (!child || child.exitCode !== null || child.pid === undefined) {
+      return;
+    }
+    try {
+      // Negative pid targets the whole process group (the host was started detached).
+      process.kill(-child.pid, 'SIGTERM');
+    } catch {
+      // Best effort; ignore (the process may have already exited).
+    }
   }
 
   private _handleMessage(message: IWebSocketEventMessage): void {

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -4,10 +4,12 @@
 import * as https from 'node:https';
 import type { ClientRequest, IncomingMessage } from 'node:http';
 import { spawn, type ChildProcess } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 
 import { WebSocket, type RawData } from 'ws';
 
-import { Executable, SubprocessTerminator } from '@rushstack/node-core-library';
+import { LockFile } from '@rushstack/node-core-library';
 
 import type {
   IOperationInfo,
@@ -16,22 +18,26 @@ import type {
   IWebSocketEventMessage,
   ReadableOperationStatus
 } from './protocol.types';
+import { clearDiscovery, isProcessAlive, readDiscovery } from '../daemon/discoveryFile';
 
 /**
  * The default WebSocket URL for the build status server. Override with the
- * `RUSHMCP_BUILD_STATUS_WS_URL` environment variable to match the `buildStatusWebSocketPath`
- * and port configured for `@rushstack/rush-serve-plugin`.
+ * `RUSHMCP_BUILD_STATUS_WS_URL` environment variable to attach to a specific (e.g. externally started)
+ * build host. When unset, the client discovers/starts the shared daemon.
  */
 const DEFAULT_WEB_SOCKET_URL: string = 'wss://localhost:8443/';
 
-/** Default command used to start a build host when none is reachable. */
+/** Default command the daemon uses to start the watch. */
 const DEFAULT_START_COMMAND: string = 'rush start';
 
 const CONNECT_TIMEOUT_MS: number = 15000;
 const DEFAULT_START_TIMEOUT_MS: number = 180000;
+const DISCOVERY_POLL_MS: number = 250;
+const STOP_TIMEOUT_MS: number = 10000;
 
-/** Matches the `https://<host>:<port>/` line that rush-serve logs once it begins serving. */
-const SERVE_URL_REGEX: RegExp = /https:\/\/([a-zA-Z0-9.-]+):(\d+)\//;
+function delayAsync(milliseconds: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
 
 /**
  * A point-in-time view of the build host's state.
@@ -46,15 +52,15 @@ export interface IBuildStatusSnapshot {
 export interface IRushServeClientOptions {
   /** The full WebSocket URL of the build status server, e.g. `wss://localhost:8443/`. */
   webSocketUrl: string;
-  /** If true, start a build host (`rush start`) when none is reachable. Default true. */
+  /** If true, start the shared daemon when no host is reachable. Default true. */
   autoStart: boolean;
-  /** The executable to start a build host with, e.g. `rush`. */
+  /** The executable the daemon uses to start the watch, e.g. `rush`. */
   startCommand: string;
   /** The arguments for the start command, e.g. `["start"]`. */
   startArgs: string[];
-  /** The working directory in which to start the build host (the Rush workspace root). */
+  /** The Rush workspace root. */
   workspacePath: string;
-  /** How long to wait for a spawned build host to begin serving before giving up. */
+  /** How long to wait for a starting daemon to begin serving before giving up. */
   startTimeoutMs: number;
 }
 
@@ -89,9 +95,10 @@ function toHttpsOrigin(wsUrl: string): string {
 }
 
 /**
- * A client that connects to the live build status WebSocket served by `@rushstack/rush-serve-plugin`.
- * If no host is reachable and `autoStart` is enabled, it starts one (`rush start`), discovers the
- * port it serves on, and connects. The connection is established lazily on first use.
+ * A client for the shared Rush build host. It connects to the watch served by the `BuildHostDaemon`
+ * (`@rushstack/rush-serve-plugin` under the hood), discovering it via `common/temp/rushmcp-build-host.json`
+ * and starting the daemon if none is running. The daemon (not this client) owns the watch, so the watch
+ * is shared across MCP clients and survives them. Connection is established lazily on first use.
  */
 export class RushServeClient {
   private readonly _configuredWebSocketUrl: string;
@@ -100,15 +107,13 @@ export class RushServeClient {
   private readonly _startArgs: string[];
   private readonly _workspacePath: string;
   private readonly _startTimeoutMs: number;
-  // The serve plugin uses a self-signed debug certificate. For localhost dev tooling we skip
-  // verification.
+  // The serve plugin uses a self-signed debug certificate. For localhost dev tooling we skip verification.
   // TODO (hardening): trust the CA via @rushstack/debug-certificate-manager instead of disabling it.
   private readonly _httpsAgent: https.Agent;
 
   private _httpsOrigin: string;
   private _webSocket: WebSocket | undefined;
   private _readyPromise: Promise<void> | undefined;
-  private _spawnedChild: ChildProcess | undefined;
 
   private _overallStatus: ReadableOperationStatus;
   private _sessionInfo: IRushSessionInfo | undefined;
@@ -134,8 +139,8 @@ export class RushServeClient {
   }
 
   /**
-   * Ensures the client is connected and has received an initial snapshot. If no host is reachable and
-   * autostart is enabled, starts one first. Safe to call repeatedly.
+   * Ensures the client is connected and has received an initial snapshot, discovering or starting the
+   * shared daemon as needed. Safe to call repeatedly.
    */
   public async ensureReadyAsync(): Promise<void> {
     if (this._webSocket && this._webSocket.readyState === WebSocket.OPEN) {
@@ -164,6 +169,11 @@ export class RushServeClient {
     };
   }
 
+  /** True if currently connected to a build host. */
+  public isConnected(): boolean {
+    return !!this._webSocket && this._webSocket.readyState === WebSocket.OPEN;
+  }
+
   /**
    * Returns the operations in the current snapshot that match the given project and/or phase.
    */
@@ -188,6 +198,62 @@ export class RushServeClient {
       throw new Error('Not connected to the Rush build host.');
     }
     this._webSocket.send(JSON.stringify(message));
+  }
+
+  /**
+   * Stops the shared build host daemon (if one is running), releasing the repository lock. Returns true
+   * if a daemon was stopped. The daemon restarts automatically the next time the host is needed.
+   */
+  public async stopDaemonAsync(): Promise<boolean> {
+    const webSocket: WebSocket | undefined = this._webSocket;
+    this._webSocket = undefined;
+    this._readyPromise = undefined;
+    if (webSocket) {
+      try {
+        webSocket.close();
+      } catch {
+        // ignore
+      }
+    }
+
+    const info: ReturnType<typeof readDiscovery> = readDiscovery(this._workspacePath);
+    if (!info) {
+      return false;
+    }
+
+    const { daemonPid } = info;
+    try {
+      process.kill(daemonPid, 'SIGTERM');
+    } catch {
+      // Already gone.
+    }
+
+    const deadline: number = Date.now() + STOP_TIMEOUT_MS;
+    while (Date.now() < deadline && isProcessAlive(daemonPid)) {
+      await delayAsync(DISCOVERY_POLL_MS);
+    }
+    if (isProcessAlive(daemonPid)) {
+      try {
+        process.kill(daemonPid, 'SIGKILL');
+      } catch {
+        // ignore
+      }
+    }
+    // The daemon clears the discovery file on exit; clear defensively in case it was force-killed.
+    try {
+      clearDiscovery(this._workspacePath);
+    } catch {
+      // ignore
+    }
+    return true;
+  }
+
+  /**
+   * No-op: the shared daemon is intentionally NOT stopped when a client disposes, so it survives for
+   * other clients. Use {@link stopDaemonAsync} (or the shutdown tool) to stop it explicitly.
+   */
+  public disposeAsync(): void {
+    // Intentionally empty.
   }
 
   /**
@@ -229,70 +295,40 @@ export class RushServeClient {
     });
   }
 
-  /**
-   * Terminates a build host that this client started (if any). No-op if the host was not started by us.
-   */
-  public disposeAsync(): void {
-    this._killSpawnedHost();
-  }
-
-  /** True if this client started the build host (so it is safe for us to stop it). */
-  public isHostSpawnedByUs(): boolean {
-    return !!this._spawnedChild && this._spawnedChild.exitCode === null;
-  }
-
-  /** True if currently connected to a build host. */
-  public isConnected(): boolean {
-    return !!this._webSocket && this._webSocket.readyState === WebSocket.OPEN;
-  }
-
-  /**
-   * Stops the build host this client started (releasing the repository lock) and resets the connection
-   * so the next `ensureReadyAsync()` re-establishes it. No-op if we did not start one. Resolves once the
-   * host process has actually exited.
-   */
-  public async stopSpawnedHostAsync(): Promise<void> {
-    const child: ChildProcess | undefined = this._spawnedChild;
-    const webSocket: WebSocket | undefined = this._webSocket;
-    this._webSocket = undefined;
-    this._readyPromise = undefined;
-    if (webSocket) {
-      try {
-        webSocket.close();
-      } catch {
-        // ignore
-      }
-    }
-    if (!child || child.exitCode !== null) {
-      this._spawnedChild = undefined;
-      return;
-    }
-    const exited: Promise<void> = new Promise<void>((resolve) => {
-      child.once('exit', () => resolve());
-    });
-    this._killSpawnedHost();
-    await exited;
-    this._spawnedChild = undefined;
-  }
-
   private async _establishConnectionAsync(): Promise<void> {
-    // 1. Try to connect to an already-running host.
+    // 1. Try the configured URL (an explicitly-specified or externally-started host).
     try {
       await this._connectToUrlAsync(this._configuredWebSocketUrl);
       return;
-    } catch (initialError) {
-      if (!this._autoStart) {
-        throw new Error(
-          `Could not connect to the Rush build host at ${this._configuredWebSocketUrl}: ` +
-            `${(initialError as Error).message}\n` +
-            `Start one with "${this._startCommand} ${this._startArgs.join(' ')}" (with ` +
-            `@rushstack/rush-serve-plugin enabled), or enable autostart (RUSHMCP_BUILD_AUTOSTART=1).`
-        );
+    } catch {
+      // fall through
+    }
+
+    // 2. Try a daemon advertised in the discovery file.
+    const existing: ReturnType<typeof readDiscovery> = readDiscovery(this._workspacePath);
+    if (existing) {
+      try {
+        await this._connectToUrlAsync(existing.webSocketUrl);
+        return;
+      } catch {
+        // The discovery file is stale or the host is unreachable; remove it and start fresh.
+        try {
+          clearDiscovery(this._workspacePath);
+        } catch {
+          // ignore
+        }
       }
     }
 
-    // 2. Nothing reachable: start a host and connect to it.
-    const startedUrl: string = await this._spawnHostAndGetUrlAsync();
+    // 3. Start the shared daemon and connect to it.
+    if (!this._autoStart) {
+      throw new Error(
+        `Could not connect to a Rush build host (configured URL ${this._configuredWebSocketUrl} and no ` +
+          `running daemon). Start one with "${this._startCommand} ${this._startArgs.join(' ')}" + ` +
+          `@rushstack/rush-serve-plugin, or enable autostart (RUSHMCP_BUILD_AUTOSTART=1).`
+      );
+    }
+    const startedUrl: string = await this._startDaemonAndGetUrlAsync();
     await this._connectToUrlAsync(startedUrl);
   }
 
@@ -318,13 +354,11 @@ export class RushServeClient {
         }
         this._handleMessage(message);
 
-        // The first message after connecting is a 'sync', which means our snapshot is now populated.
         if (!settled && message.event === 'sync') {
           settled = true;
           clearTimeout(timeout);
           this._webSocket = webSocket;
           this._httpsOrigin = toHttpsOrigin(url);
-          // Reconnect on a future close.
           webSocket.on('close', () => {
             this._webSocket = undefined;
             this._readyPromise = undefined;
@@ -352,98 +386,54 @@ export class RushServeClient {
   }
 
   /**
-   * Starts a build host and resolves with the WebSocket URL it serves on (discovered by scraping the
-   * serve URL it prints to stdout).
+   * Starts the shared build host daemon (detached, so it outlives this process) and resolves with the
+   * WebSocket URL it advertises once it begins serving. Serialized with a lock so concurrent clients
+   * do not each start a daemon.
    */
-  private async _spawnHostAndGetUrlAsync(): Promise<string> {
-    const resolvedCommand: string | undefined = Executable.tryResolve(this._startCommand);
-    if (!resolvedCommand) {
-      throw new Error(`Cannot start a build host: command "${this._startCommand}" was not found on PATH.`);
-    }
-
-    // Strip our own config vars from the child's environment so they can't confuse Rush. (Rush also
-    // rejects any unrecognized variable that starts with the reserved "RUSH_" prefix, which is why
-    // these are named "RUSHMCP_" rather than "RUSH_".)
-    const childEnv: NodeJS.ProcessEnv = { ...process.env };
-    for (const key of Object.keys(childEnv)) {
-      if (key.startsWith('RUSHMCP_')) {
-        delete childEnv[key];
+  private async _startDaemonAndGetUrlAsync(): Promise<string> {
+    const commonTempFolder: string = path.join(this._workspacePath, 'common', 'temp');
+    const launchLock: LockFile = await LockFile.acquireAsync(commonTempFolder, 'rushmcp-daemon-launch');
+    try {
+      // Another client may have started the daemon while we waited for the lock.
+      const existing: ReturnType<typeof readDiscovery> = readDiscovery(this._workspacePath);
+      if (existing) {
+        return existing.webSocketUrl;
       }
-    }
 
-    const child: ChildProcess = spawn(resolvedCommand, this._startArgs, {
-      cwd: this._workspacePath,
-      // detached (on POSIX) lets SubprocessTerminator terminate the whole process tree.
-      ...SubprocessTerminator.RECOMMENDED_OPTIONS,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      env: childEnv
-    });
-    this._spawnedChild = child;
-    // Terminate the host (and its descendants) if this process exits or is signalled.
-    SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
+      const daemonScript: string = path.resolve(__dirname, '..', 'daemon', 'start.js');
+      const logPath: string = path.join(commonTempFolder, 'rushmcp-build-host.log');
+      const logFd: number = fs.openSync(logPath, 'a');
+      let child: ChildProcess;
+      try {
+        child = spawn(process.execPath, [daemonScript, this._workspacePath], {
+          cwd: this._workspacePath,
+          // Detached + unref so the daemon outlives this client (the daemon owns the watch).
+          detached: true,
+          stdio: ['ignore', logFd, logFd],
+          env: process.env
+        });
+      } finally {
+        fs.closeSync(logFd);
+      }
+      child.unref();
 
-    // The path of the WebSocket endpoint comes from the configured URL; the host:port is discovered.
-    const webSocketPath: string = new URL(this._configuredWebSocketUrl).pathname;
-
-    return await new Promise<string>((resolve, reject) => {
-      let settled: boolean = false;
-      let buffer: string = '';
-
-      const timeout: NodeJS.Timeout = setTimeout(() => {
-        if (!settled) {
-          settled = true;
-          this._killSpawnedHost();
-          reject(
-            new Error(
-              `Timed out after ${this._startTimeoutMs}ms waiting for "${this._startCommand} ` +
-                `${this._startArgs.join(' ')}" to begin serving.`
-            )
+      const deadline: number = Date.now() + this._startTimeoutMs;
+      while (Date.now() < deadline) {
+        const info: ReturnType<typeof readDiscovery> = readDiscovery(this._workspacePath);
+        if (info) {
+          return info.webSocketUrl;
+        }
+        if (child.exitCode !== null) {
+          throw new Error(
+            `The build host daemon exited (code ${child.exitCode}) before serving. See ${logPath}.`
           );
         }
-      }, this._startTimeoutMs);
-
-      const onData = (chunk: Buffer): void => {
-        // Keep consuming output even after we've found the URL so the child's pipe never blocks.
-        if (settled) {
-          return;
-        }
-        buffer += chunk.toString();
-        const match: RegExpMatchArray | null = buffer.match(SERVE_URL_REGEX);
-        if (match) {
-          settled = true;
-          clearTimeout(timeout);
-          resolve(`wss://${match[1]}:${match[2]}${webSocketPath}`);
-        }
-      };
-
-      child.stdout?.on('data', onData);
-      child.stderr?.on('data', onData);
-
-      child.on('error', (error: Error) => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timeout);
-          reject(new Error(`Failed to start build host: ${error.message}`));
-        }
-      });
-
-      child.on('exit', (code: number | null) => {
-        if (!settled) {
-          settled = true;
-          clearTimeout(timeout);
-          reject(new Error(`Build host exited (code ${code}) before it began serving.`));
-        }
-      });
-    });
-  }
-
-  private _killSpawnedHost(): void {
-    const child: ChildProcess | undefined = this._spawnedChild;
-    if (!child) {
-      return;
+        await delayAsync(DISCOVERY_POLL_MS);
+      }
+      throw new Error(`Timed out waiting for the build host daemon to start. See ${logPath}.`);
+    } finally {
+      launchLock.release();
     }
-    // Terminates the entire process tree (SIGKILL of the group on POSIX, TaskKill /T on Windows).
-    SubprocessTerminator.killProcessTree(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
   }
 
   private _handleMessage(message: IWebSocketEventMessage): void {

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -1,0 +1,241 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as https from 'node:https';
+import type { ClientRequest, IncomingMessage } from 'node:http';
+
+import { WebSocket, type RawData } from 'ws';
+
+import type {
+  IOperationInfo,
+  IRushSessionInfo,
+  IWebSocketEventMessage,
+  ReadableOperationStatus
+} from './protocol.types';
+
+/**
+ * The default WebSocket URL for the build status server. Override with the
+ * `RUSH_BUILD_STATUS_WS_URL` environment variable to match the `buildStatusWebSocketPath`
+ * and port configured for `@rushstack/rush-serve-plugin`.
+ */
+const DEFAULT_WEB_SOCKET_URL: string = 'wss://localhost:8443/';
+
+const CONNECT_TIMEOUT_MS: number = 15000;
+
+/**
+ * A point-in-time view of the build host's state.
+ */
+export interface IBuildStatusSnapshot {
+  connected: boolean;
+  overallStatus: ReadableOperationStatus;
+  sessionInfo: IRushSessionInfo | undefined;
+  operations: IOperationInfo[];
+}
+
+export interface IRushServeClientOptions {
+  /** The full WebSocket URL of the build status server, e.g. `wss://localhost:8443/`. */
+  webSocketUrl: string;
+}
+
+/**
+ * Resolves the build host connection options from the environment.
+ */
+export function getBuildHostConfigFromEnv(): IRushServeClientOptions {
+  // eslint-disable-next-line dot-notation
+  const webSocketUrl: string = process.env['RUSH_BUILD_STATUS_WS_URL'] || DEFAULT_WEB_SOCKET_URL;
+  return { webSocketUrl };
+}
+
+/**
+ * A client that connects to the live build status WebSocket served by `@rushstack/rush-serve-plugin`
+ * (typically from a running `rush start`), maintains an in-memory snapshot of the build graph, and
+ * fetches per-operation logs over HTTPS.
+ *
+ * The connection is established lazily on first use, so constructing this client is free and does not
+ * require a running build host.
+ */
+export class RushServeClient {
+  private readonly _webSocketUrl: string;
+  private readonly _httpsOrigin: string;
+  // The serve plugin uses a self-signed debug certificate. For localhost dev tooling we skip
+  // verification.
+  // TODO (hardening): trust the CA via @rushstack/debug-certificate-manager instead of disabling it.
+  private readonly _httpsAgent: https.Agent;
+
+  private _webSocket: WebSocket | undefined;
+  private _readyPromise: Promise<void> | undefined;
+
+  private _overallStatus: ReadableOperationStatus;
+  private _sessionInfo: IRushSessionInfo | undefined;
+  private readonly _operationsByName: Map<string, IOperationInfo>;
+
+  public constructor(options: IRushServeClientOptions) {
+    this._webSocketUrl = options.webSocketUrl;
+
+    const httpsUrl: URL = new URL(this._webSocketUrl);
+    httpsUrl.protocol = httpsUrl.protocol === 'wss:' ? 'https:' : 'http:';
+    this._httpsOrigin = httpsUrl.origin;
+
+    this._httpsAgent = new https.Agent({ rejectUnauthorized: false });
+
+    this._overallStatus = 'Ready';
+    this._operationsByName = new Map();
+  }
+
+  public get webSocketUrl(): string {
+    return this._webSocketUrl;
+  }
+
+  /**
+   * Ensures the client is connected and has received an initial snapshot. Safe to call repeatedly;
+   * it will reconnect if a previous connection was closed.
+   */
+  public async ensureReadyAsync(): Promise<void> {
+    if (this._webSocket && this._webSocket.readyState === WebSocket.OPEN) {
+      return;
+    }
+    if (!this._readyPromise) {
+      this._readyPromise = this._connectAsync();
+    }
+    await this._readyPromise;
+  }
+
+  /**
+   * Returns the current in-memory snapshot of the build host's state.
+   */
+  public getSnapshot(): IBuildStatusSnapshot {
+    return {
+      connected: !!this._webSocket && this._webSocket.readyState === WebSocket.OPEN,
+      overallStatus: this._overallStatus,
+      sessionInfo: this._sessionInfo,
+      operations: Array.from(this._operationsByName.values())
+    };
+  }
+
+  /**
+   * Fetches the contents of a log file by its serve-relative URL (as found in `IOperationInfo.logFileURLs`).
+   * Resolves to `undefined` if the log file does not exist (HTTP 404); for example, the stderr log is only
+   * written when an operation produces stderr output.
+   */
+  public async fetchLogTextAsync(relativeUrl: string): Promise<string | undefined> {
+    const fullUrl: string = `${this._httpsOrigin}${relativeUrl}`;
+    return await new Promise<string | undefined>((resolve, reject) => {
+      const request: ClientRequest = https.get(
+        fullUrl,
+        { agent: this._httpsAgent },
+        (response: IncomingMessage) => {
+          const statusCode: number = response.statusCode ?? 0;
+          if (statusCode === 404) {
+            response.resume();
+            resolve(undefined);
+            return;
+          }
+          if (statusCode < 200 || statusCode >= 300) {
+            response.resume();
+            reject(new Error(`Failed to fetch log at ${fullUrl}: HTTP ${statusCode}`));
+            return;
+          }
+          let body: string = '';
+          response.setEncoding('utf8');
+          response.on('data', (chunk: string) => {
+            body += chunk;
+          });
+          response.on('end', () => {
+            resolve(body);
+          });
+        }
+      );
+      request.on('error', (error: Error) => {
+        reject(new Error(`Failed to fetch log at ${fullUrl}: ${error.message}`));
+      });
+    });
+  }
+
+  private async _connectAsync(): Promise<void> {
+    return await new Promise<void>((resolve, reject) => {
+      const webSocket: WebSocket = new WebSocket(this._webSocketUrl, { rejectUnauthorized: false });
+      let settled: boolean = false;
+
+      const timeout: NodeJS.Timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          this._readyPromise = undefined;
+          webSocket.terminate();
+          reject(new Error(`Timed out connecting to the Rush build host at ${this._webSocketUrl}.`));
+        }
+      }, CONNECT_TIMEOUT_MS);
+
+      webSocket.on('message', (data: RawData) => {
+        let message: IWebSocketEventMessage;
+        try {
+          message = JSON.parse(data.toString());
+        } catch {
+          // Ignore malformed messages.
+          return;
+        }
+        this._handleMessage(message);
+
+        // The first message after connecting is a 'sync', which means our snapshot is now populated.
+        if (!settled && message.event === 'sync') {
+          settled = true;
+          clearTimeout(timeout);
+          this._webSocket = webSocket;
+          resolve();
+        }
+      });
+
+      webSocket.on('error', (error: Error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          this._readyPromise = undefined;
+          reject(
+            new Error(
+              `Could not connect to the Rush build host at ${this._webSocketUrl}: ${error.message}\n` +
+                `Is "rush start" (or another watch command) running with @rushstack/rush-serve-plugin and a ` +
+                `matching "buildStatusWebSocketPath"? You can override the URL with the ` +
+                `RUSH_BUILD_STATUS_WS_URL environment variable.`
+            )
+          );
+        }
+      });
+
+      webSocket.on('close', () => {
+        this._webSocket = undefined;
+        this._readyPromise = undefined;
+      });
+    });
+  }
+
+  private _handleMessage(message: IWebSocketEventMessage): void {
+    switch (message.event) {
+      case 'sync': {
+        this._operationsByName.clear();
+        this._sessionInfo = message.sessionInfo;
+        this._overallStatus = message.status;
+        this._mergeOperations(message.operations);
+        break;
+      }
+      case 'before-execute': {
+        this._overallStatus = 'Executing';
+        this._mergeOperations(message.operations);
+        break;
+      }
+      case 'status-change': {
+        this._mergeOperations(message.operations);
+        break;
+      }
+      case 'after-execute': {
+        this._overallStatus = message.status;
+        this._mergeOperations(message.operations);
+        break;
+      }
+    }
+  }
+
+  private _mergeOperations(operations: IOperationInfo[]): void {
+    for (const operation of operations) {
+      this._operationsByName.set(operation.name, operation);
+    }
+  }
+}

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -9,6 +9,7 @@ import { WebSocket, type RawData } from 'ws';
 import type {
   IOperationInfo,
   IRushSessionInfo,
+  IWebSocketCommandMessage,
   IWebSocketEventMessage,
   ReadableOperationStatus
 } from './protocol.types';
@@ -110,6 +111,32 @@ export class RushServeClient {
       sessionInfo: this._sessionInfo,
       operations: Array.from(this._operationsByName.values())
     };
+  }
+
+  /**
+   * Returns the operations in the current snapshot that match the given project and/or phase.
+   */
+  public findOperations(filter: { project?: string; phase?: string }): IOperationInfo[] {
+    let operations: IOperationInfo[] = Array.from(this._operationsByName.values());
+    if (filter.project !== undefined) {
+      operations = operations.filter((operation) => operation.packageName === filter.project);
+    }
+    if (filter.phase !== undefined) {
+      operations = operations.filter((operation) => operation.phaseName === filter.phase);
+    }
+    return operations;
+  }
+
+  /**
+   * Sends a command to the build host. Commands are fire-and-forget; their effect is observed via
+   * subsequent status events.
+   */
+  public async sendCommandAsync(message: IWebSocketCommandMessage): Promise<void> {
+    await this.ensureReadyAsync();
+    if (!this._webSocket || this._webSocket.readyState !== WebSocket.OPEN) {
+      throw new Error('Not connected to the Rush build host.');
+    }
+    this._webSocket.send(JSON.stringify(message));
   }
 
   /**

--- a/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
+++ b/apps/rush-mcp-server/src/buildHost/RushServeClient.ts
@@ -236,6 +236,45 @@ export class RushServeClient {
     this._killSpawnedHost();
   }
 
+  /** True if this client started the build host (so it is safe for us to stop it). */
+  public isHostSpawnedByUs(): boolean {
+    return !!this._spawnedChild && this._spawnedChild.exitCode === null;
+  }
+
+  /** True if currently connected to a build host. */
+  public isConnected(): boolean {
+    return !!this._webSocket && this._webSocket.readyState === WebSocket.OPEN;
+  }
+
+  /**
+   * Stops the build host this client started (releasing the repository lock) and resets the connection
+   * so the next `ensureReadyAsync()` re-establishes it. No-op if we did not start one. Resolves once the
+   * host process has actually exited.
+   */
+  public async stopSpawnedHostAsync(): Promise<void> {
+    const child: ChildProcess | undefined = this._spawnedChild;
+    const webSocket: WebSocket | undefined = this._webSocket;
+    this._webSocket = undefined;
+    this._readyPromise = undefined;
+    if (webSocket) {
+      try {
+        webSocket.close();
+      } catch {
+        // ignore
+      }
+    }
+    if (!child || child.exitCode !== null) {
+      this._spawnedChild = undefined;
+      return;
+    }
+    const exited: Promise<void> = new Promise<void>((resolve) => {
+      child.once('exit', () => resolve());
+    });
+    this._killSpawnedHost();
+    await exited;
+    this._spawnedChild = undefined;
+  }
+
   private async _establishConnectionAsync(): Promise<void> {
     // 1. Try to connect to an already-running host.
     try {

--- a/apps/rush-mcp-server/src/buildHost/protocol.types.ts
+++ b/apps/rush-mcp-server/src/buildHost/protocol.types.ts
@@ -107,3 +107,44 @@ export type IWebSocketEventMessage =
   | IWebSocketAfterExecuteEventMessage
   | IWebSocketBatchStatusChangeEventMessage
   | IWebSocketSyncEventMessage;
+
+/**
+ * The set of possible enabled states for an operation, used by the "set-enabled-states" command.
+ *
+ * - `never`: never build this operation
+ * - `changed`: build only when its own project has directly changed
+ * - `affected`: always build when reached (changed or downstream of a change)
+ * - `default`: restore the command's original behavior
+ */
+export type OperationEnabledState = 'never' | 'changed' | 'affected' | 'default';
+
+/** Asks the build host to resend a full `sync` snapshot. */
+export interface IWebSocketSyncCommandMessage {
+  command: 'sync';
+}
+
+/** Asks the build host to abort the current execution pass. */
+export interface IWebSocketAbortExecutionCommandMessage {
+  command: 'abort-execution';
+}
+
+/** Asks the build host to invalidate (and thus rebuild) the named operations. */
+export interface IWebSocketInvalidateCommandMessage {
+  command: 'invalidate';
+  operationNames: string[];
+}
+
+/** Asks the build host to change the enabled state of the named operations. */
+export interface IWebSocketSetEnabledStatesCommandMessage {
+  command: 'set-enabled-states';
+  enabledStateByOperationName: Record<string, OperationEnabledState>;
+}
+
+/**
+ * The set of possible messages sent from a client to the build host.
+ */
+export type IWebSocketCommandMessage =
+  | IWebSocketSyncCommandMessage
+  | IWebSocketAbortExecutionCommandMessage
+  | IWebSocketInvalidateCommandMessage
+  | IWebSocketSetEnabledStatesCommandMessage;

--- a/apps/rush-mcp-server/src/buildHost/protocol.types.ts
+++ b/apps/rush-mcp-server/src/buildHost/protocol.types.ts
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+/**
+ * Wire protocol for the live build status WebSocket exposed by `@rushstack/rush-serve-plugin`.
+ *
+ * This is a hand-maintained mirror of the subset of `@rushstack/rush-serve-plugin/api` that this
+ * MCP server consumes. It is duplicated (rather than imported) to keep `@rushstack/mcp-server` free
+ * of a runtime dependency on the serve plugin. Keep it in sync with that package's `api.types.ts`.
+ */
+
+/**
+ * Human readable status values. These are the PascalCase keys of the `OperationStatus` enumeration.
+ */
+export type ReadableOperationStatus =
+  | 'Waiting'
+  | 'Ready'
+  | 'Queued'
+  | 'Executing'
+  | 'Success'
+  | 'SuccessWithWarning'
+  | 'Skipped'
+  | 'FromCache'
+  | 'Failure'
+  | 'Blocked'
+  | 'NoOp'
+  | 'Aborted';
+
+/**
+ * Relative URLs (rooted at the serve origin) to the log files for an operation.
+ */
+export interface ILogFileURLs {
+  /** The relative URL to the merged (interleaved stdout and stderr) text log. */
+  text: string;
+  /** The relative URL to the stderr log file. */
+  error: string;
+  /** The relative URL to the JSONL log file. */
+  jsonl: string;
+}
+
+/**
+ * Information about a single operation in the build graph.
+ */
+export interface IOperationInfo {
+  /** The display name of the operation, e.g. `my-project (build)`. */
+  name: string;
+  /** The display names of the operation's dependencies. */
+  dependencies: string[];
+  /** The npm package name of the containing Rush project. */
+  packageName: string;
+  /** The name of the containing phase, e.g. `_phase:build`. */
+  phaseName: string;
+  /** If false, this operation is disabled and will report as `Skipped`. */
+  enabled: boolean;
+  /** If true, this operation is architectural and included only for graph completeness. */
+  silent: boolean;
+  /** If true, this operation is a no-op and included only for graph completeness. */
+  noop: boolean;
+  /** The current status of the operation. */
+  status: ReadableOperationStatus;
+  /** The URLs to the log files, if applicable. */
+  logFileURLs: ILogFileURLs | undefined;
+  /** The start time of the operation in milliseconds (not wall clock), if started. */
+  startTime: number | undefined;
+  /** The end time of the operation in milliseconds (not wall clock), if finished. */
+  endTime: number | undefined;
+}
+
+/**
+ * Information about the current Rush session.
+ */
+export interface IRushSessionInfo {
+  /** The name of the command being run, e.g. `start`. */
+  actionName: string;
+  /** A unique identifier for the repository in which this Rush is running. */
+  repositoryIdentifier: string;
+}
+
+export interface IWebSocketBeforeExecuteEventMessage {
+  event: 'before-execute';
+  operations: IOperationInfo[];
+}
+
+export interface IWebSocketAfterExecuteEventMessage {
+  event: 'after-execute';
+  operations: IOperationInfo[];
+  status: ReadableOperationStatus;
+}
+
+export interface IWebSocketBatchStatusChangeEventMessage {
+  event: 'status-change';
+  operations: IOperationInfo[];
+}
+
+export interface IWebSocketSyncEventMessage {
+  event: 'sync';
+  operations: IOperationInfo[];
+  sessionInfo: IRushSessionInfo;
+  status: ReadableOperationStatus;
+}
+
+/**
+ * The set of possible messages sent from the build host to a connected client.
+ */
+export type IWebSocketEventMessage =
+  | IWebSocketBeforeExecuteEventMessage
+  | IWebSocketAfterExecuteEventMessage
+  | IWebSocketBatchStatusChangeEventMessage
+  | IWebSocketSyncEventMessage;

--- a/apps/rush-mcp-server/src/daemon/BuildHostDaemon.ts
+++ b/apps/rush-mcp-server/src/daemon/BuildHostDaemon.ts
@@ -12,6 +12,15 @@ import { clearDiscovery, writeDiscovery } from './discoveryFile';
 /** Matches the `https://<host>:<port>/` line that rush-serve logs once it begins serving. */
 const SERVE_URL_REGEX: RegExp = /https:\/\/([a-zA-Z0-9.-]+):(\d+)\//;
 
+const RESTART_DELAY_MS: number = 1000;
+/** A watch that exits within this window of starting is treated as a crash for back-off purposes. */
+const FAST_FAILURE_WINDOW_MS: number = 5000;
+const MAX_CONSECUTIVE_FAILURES: number = 3;
+
+function delayAsync(milliseconds: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
 export interface IBuildHostDaemonOptions {
   /** The Rush workspace root. */
   workspacePath: string;
@@ -50,7 +59,8 @@ export class BuildHostDaemon {
     }
 
     let child: ChildProcess | undefined;
-    // Clean up the discovery file no matter how we exit.
+
+    // Clean up the discovery file no matter how we exit (including process.exit on a signal).
     process.once('exit', () => {
       try {
         clearDiscovery(workspacePath);
@@ -58,25 +68,48 @@ export class BuildHostDaemon {
         // ignore
       }
     });
+    // On a signal, exit; the 'exit' handler clears discovery and SubprocessTerminator reaps the watch.
     process.once('SIGINT', () => process.exit(0));
     process.once('SIGTERM', () => process.exit(0));
 
     try {
-      child = this._spawnWatch();
-      // Reap the watch tree when this daemon exits or is signalled.
-      SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
+      // Supervision loop: keep the watch running, restarting it if it exits unexpectedly (each restart
+      // re-advertises the new port; connected clients reconnect via the discovery file). The loop ends
+      // only if the watch crash-loops; the counter is the loop condition.
+      let consecutiveFailures: number = 0;
+      while (consecutiveFailures < MAX_CONSECUTIVE_FAILURES) {
+        const startedAt: number = Date.now();
+        child = this._spawnWatch();
+        // Reap the watch tree if this daemon exits or is signalled.
+        SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
 
-      const webSocketUrl: string = await this._discoverServeUrlAsync(child);
-      writeDiscovery(workspacePath, {
-        webSocketUrl,
-        daemonPid: process.pid,
-        startedAt: new Date().toISOString()
-      });
-      process.stdout.write(`Build host ready at ${webSocketUrl} (daemon pid ${process.pid}).\n`);
+        let webSocketUrl: string;
+        try {
+          webSocketUrl = await this._discoverServeUrlAsync(child);
+        } catch (error) {
+          consecutiveFailures++;
+          process.stderr.write(`Watch failed to start: ${(error as Error).message}\n`);
+          await delayAsync(RESTART_DELAY_MS);
+          continue;
+        }
 
-      // Stay alive until the watch exits (a signal triggers process.exit above, which kills the watch).
-      await once(child, 'exit');
-      process.stdout.write('Watch process exited; shutting down daemon.\n');
+        writeDiscovery(workspacePath, {
+          webSocketUrl,
+          daemonPid: process.pid,
+          startedAt: new Date().toISOString()
+        });
+        process.stdout.write(`Build host ready at ${webSocketUrl} (daemon pid ${process.pid}).\n`);
+
+        await once(child, 'exit');
+
+        // The watch exited on its own. Drop the advertisement and restart unless it's crash-looping
+        // (a watch that ran long enough before exiting resets the failure counter).
+        clearDiscovery(workspacePath);
+        consecutiveFailures = Date.now() - startedAt < FAST_FAILURE_WINDOW_MS ? consecutiveFailures + 1 : 0;
+        process.stderr.write('Watch exited; restarting...\n');
+        await delayAsync(RESTART_DELAY_MS);
+      }
+      process.stderr.write(`Watch crash-looped; giving up after ${MAX_CONSECUTIVE_FAILURES} failures.\n`);
     } finally {
       clearDiscovery(workspacePath);
       if (child) {

--- a/apps/rush-mcp-server/src/daemon/BuildHostDaemon.ts
+++ b/apps/rush-mcp-server/src/daemon/BuildHostDaemon.ts
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
+
+import { Executable, LockFile, SubprocessTerminator } from '@rushstack/node-core-library';
+
+import { clearDiscovery, writeDiscovery } from './discoveryFile';
+
+/** Matches the `https://<host>:<port>/` line that rush-serve logs once it begins serving. */
+const SERVE_URL_REGEX: RegExp = /https:\/\/([a-zA-Z0-9.-]+):(\d+)\//;
+
+export interface IBuildHostDaemonOptions {
+  /** The Rush workspace root. */
+  workspacePath: string;
+  /** Executable to start the watch with, e.g. `rush`. */
+  startCommand: string;
+  /** Arguments for the start command, e.g. `["start"]`. */
+  startArgs: string[];
+  /** The URL path of the WebSocket endpoint (host:port is discovered), e.g. `/`. */
+  webSocketPath: string;
+  /** How long to wait for the watch to begin serving before giving up. */
+  startTimeoutMs: number;
+}
+
+/**
+ * A long-lived supervisor process that owns a single Rush watch (`rush start` + rush-serve-plugin)
+ * and advertises it via a discovery file so multiple MCP clients can share it. The watch is owned by
+ * the daemon (not by any client), so it survives individual MCP processes and is reaped when the
+ * daemon itself exits.
+ */
+export class BuildHostDaemon {
+  private readonly _options: IBuildHostDaemonOptions;
+
+  public constructor(options: IBuildHostDaemonOptions) {
+    this._options = options;
+  }
+
+  public async runAsync(): Promise<void> {
+    const { workspacePath } = this._options;
+    const commonTempFolder: string = path.join(workspacePath, 'common', 'temp');
+
+    // Only one daemon per repo.
+    const lock: LockFile | undefined = LockFile.tryAcquire(commonTempFolder, 'rushmcp-daemon');
+    if (!lock) {
+      process.stderr.write('A rushmcp build-host daemon is already running in this repository.\n');
+      return;
+    }
+
+    let child: ChildProcess | undefined;
+    // Clean up the discovery file no matter how we exit.
+    process.once('exit', () => {
+      try {
+        clearDiscovery(workspacePath);
+      } catch {
+        // ignore
+      }
+    });
+    process.once('SIGINT', () => process.exit(0));
+    process.once('SIGTERM', () => process.exit(0));
+
+    try {
+      child = this._spawnWatch();
+      // Reap the watch tree when this daemon exits or is signalled.
+      SubprocessTerminator.killProcessTreeOnExit(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
+
+      const webSocketUrl: string = await this._discoverServeUrlAsync(child);
+      writeDiscovery(workspacePath, {
+        webSocketUrl,
+        daemonPid: process.pid,
+        startedAt: new Date().toISOString()
+      });
+      process.stdout.write(`Build host ready at ${webSocketUrl} (daemon pid ${process.pid}).\n`);
+
+      // Stay alive until the watch exits (a signal triggers process.exit above, which kills the watch).
+      await once(child, 'exit');
+      process.stdout.write('Watch process exited; shutting down daemon.\n');
+    } finally {
+      clearDiscovery(workspacePath);
+      if (child) {
+        SubprocessTerminator.killProcessTree(child, SubprocessTerminator.RECOMMENDED_OPTIONS);
+      }
+      lock.release();
+    }
+  }
+
+  private _spawnWatch(): ChildProcess {
+    const { startCommand, startArgs, workspacePath } = this._options;
+    const resolved: string | undefined = Executable.tryResolve(startCommand);
+    if (!resolved) {
+      throw new Error(`Cannot start the watch: command "${startCommand}" was not found on PATH.`);
+    }
+
+    // Don't leak our own RUSHMCP_* config into Rush (which rejects unrecognized RUSH_*-prefixed vars).
+    const childEnv: NodeJS.ProcessEnv = { ...process.env };
+    for (const key of Object.keys(childEnv)) {
+      if (key.startsWith('RUSHMCP_')) {
+        delete childEnv[key];
+      }
+    }
+
+    return spawn(resolved, startArgs, {
+      cwd: workspacePath,
+      ...SubprocessTerminator.RECOMMENDED_OPTIONS,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: childEnv
+    });
+  }
+
+  private async _discoverServeUrlAsync(child: ChildProcess): Promise<string> {
+    const { webSocketPath, startCommand, startArgs, startTimeoutMs } = this._options;
+    return await new Promise<string>((resolve, reject) => {
+      let settled: boolean = false;
+      let buffer: string = '';
+
+      const timeout: NodeJS.Timeout = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(
+              `Timed out after ${startTimeoutMs}ms waiting for "${startCommand} ${startArgs.join(' ')}" ` +
+                `to begin serving.`
+            )
+          );
+        }
+      }, startTimeoutMs);
+
+      const onData = (chunk: Buffer): void => {
+        if (settled) {
+          return;
+        }
+        buffer += chunk.toString();
+        const match: RegExpMatchArray | null = buffer.match(SERVE_URL_REGEX);
+        if (match) {
+          settled = true;
+          clearTimeout(timeout);
+          resolve(`wss://${match[1]}:${match[2]}${webSocketPath}`);
+        }
+      };
+
+      child.stdout?.on('data', onData);
+      child.stderr?.on('data', onData);
+
+      child.on('error', (error: Error) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error(`Failed to start the watch: ${error.message}`));
+        }
+      });
+
+      child.on('exit', (code: number | null) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(timeout);
+          reject(new Error(`Watch process exited (code ${code}) before it began serving.`));
+        }
+      });
+    });
+  }
+}

--- a/apps/rush-mcp-server/src/daemon/discoveryFile.ts
+++ b/apps/rush-mcp-server/src/daemon/discoveryFile.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+
+import { FileSystem, JsonFile } from '@rushstack/node-core-library';
+
+/**
+ * Written by the build-host daemon when it begins serving, so that any MCP client can discover and
+ * attach to the shared watch. Lives in `common/temp` (git-ignored).
+ */
+export interface IBuildHostDiscovery {
+  /** The WebSocket URL the shared watch is served on, e.g. `wss://localhost:43635/`. */
+  webSocketUrl: string;
+  /** The PID of the daemon process that owns the watch. Used to detect a stale discovery file. */
+  daemonPid: number;
+  /** ISO timestamp of when the daemon started serving. */
+  startedAt: string;
+}
+
+const DISCOVERY_RELATIVE_PATH: string = 'common/temp/rushmcp-build-host.json';
+
+export function getDiscoveryFilePath(workspacePath: string): string {
+  return path.join(workspacePath, DISCOVERY_RELATIVE_PATH);
+}
+
+/**
+ * Returns true if a process with the given PID exists.
+ */
+export function isProcessAlive(pid: number): boolean {
+  try {
+    // Signal 0 doesn't send a signal; it only checks for the existence of the process.
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    // EPERM means the process exists but is owned by another user.
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * Reads the discovery file, returning `undefined` if it is missing, malformed, or stale (the daemon
+ * process it points to is no longer running).
+ */
+export function readDiscovery(workspacePath: string): IBuildHostDiscovery | undefined {
+  let info: IBuildHostDiscovery;
+  try {
+    info = JsonFile.load(getDiscoveryFilePath(workspacePath));
+  } catch {
+    return undefined;
+  }
+  if (typeof info?.webSocketUrl !== 'string' || typeof info?.daemonPid !== 'number') {
+    return undefined;
+  }
+  if (!isProcessAlive(info.daemonPid)) {
+    return undefined;
+  }
+  return info;
+}
+
+export function writeDiscovery(workspacePath: string, info: IBuildHostDiscovery): void {
+  JsonFile.save(info, getDiscoveryFilePath(workspacePath), { ensureFolderExists: true });
+}
+
+export function clearDiscovery(workspacePath: string): void {
+  // FileSystem.deleteFile is a no-op if the file does not exist.
+  FileSystem.deleteFile(getDiscoveryFilePath(workspacePath));
+}

--- a/apps/rush-mcp-server/src/daemon/start.ts
+++ b/apps/rush-mcp-server/src/daemon/start.ts
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as path from 'node:path';
+
+import { getBuildHostConfigFromEnv } from '../buildHost/RushServeClient';
+import { BuildHostDaemon } from './BuildHostDaemon';
+
+async function main(): Promise<void> {
+  const workspacePath: string = path.resolve(process.argv[2] || process.cwd());
+  const config: ReturnType<typeof getBuildHostConfigFromEnv> = getBuildHostConfigFromEnv(workspacePath);
+
+  const daemon: BuildHostDaemon = new BuildHostDaemon({
+    workspacePath,
+    startCommand: config.startCommand,
+    startArgs: config.startArgs,
+    webSocketPath: new URL(config.webSocketUrl).pathname,
+    startTimeoutMs: config.startTimeoutMs
+  });
+
+  await daemon.runAsync();
+}
+
+main().catch((error: unknown) => {
+  process.stderr.write(`Build host daemon failed: ${error instanceof Error ? error.message : error}\n`);
+  process.exit(1);
+});

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -55,7 +55,7 @@ export class RushMCPServer extends McpServer {
     this._tools.push(new RushRebuildTool(this._buildHostClient));
     this._tools.push(new RushSetWatchStateTool(this._buildHostClient));
     this._tools.push(new RushAbortBuildTool(this._buildHostClient));
-    this._tools.push(new RushRunCommandTool());
+    this._tools.push(new RushRunCommandTool(this._buildHostClient));
   }
 
   private _registerTools(): void {

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -14,7 +14,8 @@ import {
   RushBuildLogsTool,
   RushRebuildTool,
   RushSetWatchStateTool,
-  RushAbortBuildTool
+  RushAbortBuildTool,
+  RushRunCommandTool
 } from './tools';
 import { RushMcpPluginLoader } from './pluginFramework/RushMcpPluginLoader';
 import { RushServeClient, getBuildHostConfigFromEnv } from './buildHost/RushServeClient';
@@ -54,6 +55,7 @@ export class RushMCPServer extends McpServer {
     this._tools.push(new RushRebuildTool(this._buildHostClient));
     this._tools.push(new RushSetWatchStateTool(this._buildHostClient));
     this._tools.push(new RushAbortBuildTool(this._buildHostClient));
+    this._tools.push(new RushRunCommandTool());
   }
 
   private _registerTools(): void {

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -9,14 +9,18 @@ import {
   RushMigrateProjectTool,
   RushCommandValidatorTool,
   RushWorkspaceDetailsTool,
-  RushProjectDetailsTool
+  RushProjectDetailsTool,
+  RushBuildStatusTool,
+  RushBuildLogsTool
 } from './tools';
 import { RushMcpPluginLoader } from './pluginFramework/RushMcpPluginLoader';
+import { RushServeClient, getBuildHostConfigFromEnv } from './buildHost/RushServeClient';
 
 export class RushMCPServer extends McpServer {
   private _rushWorkspacePath: string;
   private _tools: BaseTool[] = [];
   private _pluginLoader: RushMcpPluginLoader;
+  private _buildHostClient: RushServeClient;
 
   public constructor(rushWorkspacePath: string) {
     super({
@@ -26,6 +30,7 @@ export class RushMCPServer extends McpServer {
 
     this._rushWorkspacePath = rushWorkspacePath;
     this._pluginLoader = new RushMcpPluginLoader(this._rushWorkspacePath, this);
+    this._buildHostClient = new RushServeClient(getBuildHostConfigFromEnv());
   }
 
   public async startAsync(): Promise<void> {
@@ -41,6 +46,8 @@ export class RushMCPServer extends McpServer {
     this._tools.push(new RushCommandValidatorTool());
     this._tools.push(new RushWorkspaceDetailsTool());
     this._tools.push(new RushProjectDetailsTool());
+    this._tools.push(new RushBuildStatusTool(this._buildHostClient));
+    this._tools.push(new RushBuildLogsTool(this._buildHostClient));
   }
 
   private _registerTools(): void {

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -34,7 +34,7 @@ export class RushMCPServer extends McpServer {
 
     this._rushWorkspacePath = rushWorkspacePath;
     this._pluginLoader = new RushMcpPluginLoader(this._rushWorkspacePath, this);
-    this._buildHostClient = new RushServeClient(getBuildHostConfigFromEnv());
+    this._buildHostClient = new RushServeClient(getBuildHostConfigFromEnv(this._rushWorkspacePath));
   }
 
   public async startAsync(): Promise<void> {

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -11,7 +11,10 @@ import {
   RushWorkspaceDetailsTool,
   RushProjectDetailsTool,
   RushBuildStatusTool,
-  RushBuildLogsTool
+  RushBuildLogsTool,
+  RushRebuildTool,
+  RushSetWatchStateTool,
+  RushAbortBuildTool
 } from './tools';
 import { RushMcpPluginLoader } from './pluginFramework/RushMcpPluginLoader';
 import { RushServeClient, getBuildHostConfigFromEnv } from './buildHost/RushServeClient';
@@ -48,6 +51,9 @@ export class RushMCPServer extends McpServer {
     this._tools.push(new RushProjectDetailsTool());
     this._tools.push(new RushBuildStatusTool(this._buildHostClient));
     this._tools.push(new RushBuildLogsTool(this._buildHostClient));
+    this._tools.push(new RushRebuildTool(this._buildHostClient));
+    this._tools.push(new RushSetWatchStateTool(this._buildHostClient));
+    this._tools.push(new RushAbortBuildTool(this._buildHostClient));
   }
 
   private _registerTools(): void {

--- a/apps/rush-mcp-server/src/server.ts
+++ b/apps/rush-mcp-server/src/server.ts
@@ -15,7 +15,8 @@ import {
   RushRebuildTool,
   RushSetWatchStateTool,
   RushAbortBuildTool,
-  RushRunCommandTool
+  RushRunCommandTool,
+  RushShutdownHostTool
 } from './tools';
 import { RushMcpPluginLoader } from './pluginFramework/RushMcpPluginLoader';
 import { RushServeClient, getBuildHostConfigFromEnv } from './buildHost/RushServeClient';
@@ -56,6 +57,7 @@ export class RushMCPServer extends McpServer {
     this._tools.push(new RushSetWatchStateTool(this._buildHostClient));
     this._tools.push(new RushAbortBuildTool(this._buildHostClient));
     this._tools.push(new RushRunCommandTool(this._buildHostClient));
+    this._tools.push(new RushShutdownHostTool(this._buildHostClient));
   }
 
   private _registerTools(): void {

--- a/apps/rush-mcp-server/src/tools/build-abort.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-abort.tool.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { RushServeClient } from '../buildHost/RushServeClient';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+/**
+ * Aborts the current execution pass of the running Rush build/watch host.
+ */
+export class RushAbortBuildTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_abort_build',
+      description:
+        'Aborts the current execution pass of the running Rush build/watch host. Operations already ' +
+        'started will finish; queued operations are cancelled. Requires a running watch command ' +
+        '(e.g. "rush start") with @rushstack/rush-serve-plugin enabled.',
+      schema: {}
+    });
+    this._client = client;
+  }
+
+  public async executeAsync(): Promise<CallToolResult> {
+    await this._client.sendCommandAsync({ command: 'abort-execution' });
+    return {
+      content: [
+        {
+          type: 'text',
+          text: 'Sent abort request. Operations already started will finish; queued operations are cancelled.'
+        }
+      ]
+    };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/build-logs.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-logs.tool.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { z } from 'zod';
+
+import type { RushServeClient } from '../buildHost/RushServeClient';
+import type { IOperationInfo } from '../buildHost/protocol.types';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+const DEFAULT_TAIL_LINES: number = 200;
+
+interface IRushBuildLogsArgs {
+  project: string;
+  phase?: string;
+  errorsOnly?: boolean;
+  tailLines?: number;
+}
+
+/**
+ * Fetches the build log for a project's operation from the running Rush build host, trimmed to the
+ * tail (and optionally to stderr only) so an agent can inspect failures without ingesting whole logs.
+ */
+export class RushBuildLogsTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_build_logs',
+      description:
+        "Returns the build log for a project's operation from the running Rush build/watch host, " +
+        'trimmed to the last N lines and optionally to errors only. Requires a running watch command ' +
+        '(e.g. "rush start") with @rushstack/rush-serve-plugin enabled.',
+      schema: {
+        project: z.string().describe('The npm package name of the project.'),
+        phase: z
+          .string()
+          .optional()
+          .describe('The phase name (e.g. "_phase:build"). Required if the project has multiple phases.'),
+        errorsOnly: z
+          .boolean()
+          .optional()
+          .describe('Return only the stderr log instead of the merged stdout+stderr log.'),
+        tailLines: z
+          .number()
+          .optional()
+          .describe(`Return only the last N lines (default ${DEFAULT_TAIL_LINES}).`)
+      }
+    });
+    this._client = client;
+  }
+
+  public async executeAsync({
+    project,
+    phase,
+    errorsOnly,
+    tailLines
+  }: IRushBuildLogsArgs): Promise<CallToolResult> {
+    await this._client.ensureReadyAsync();
+    const operations: IOperationInfo[] = this._client.getSnapshot().operations;
+
+    let matches: IOperationInfo[] = operations.filter((op) => op.packageName === project);
+    if (phase) {
+      matches = matches.filter((op) => op.phaseName === phase);
+    }
+
+    if (matches.length === 0) {
+      return this._textResult(
+        phase
+          ? `No operation found for project "${project}" and phase "${phase}".`
+          : `No operations found for project "${project}".`
+      );
+    }
+
+    if (matches.length > 1) {
+      const phases: string[] = matches.map((op) => op.phaseName).sort();
+      return this._textResult(
+        `Project "${project}" has multiple phases. Specify one via the "phase" argument:\n` +
+          phases.map((name) => `  ${name}`).join('\n')
+      );
+    }
+
+    const operation: IOperationInfo = matches[0];
+    if (!operation.logFileURLs) {
+      return this._textResult(
+        `No logs are available for ${operation.name} (status: ${operation.status}). ` +
+          `It may not have run yet, or may be a no-op.`
+      );
+    }
+
+    const relativeUrl: string = errorsOnly ? operation.logFileURLs.error : operation.logFileURLs.text;
+    const rawLog: string | undefined = await this._client.fetchLogTextAsync(relativeUrl);
+
+    if (rawLog === undefined) {
+      return this._textResult(
+        `No ${errorsOnly ? 'stderr' : 'merged'} log file found for ${operation.name} ` +
+          `(status: ${operation.status}). It may have produced no ${errorsOnly ? 'errors' : 'output'}.`
+      );
+    }
+
+    const limit: number = tailLines ?? DEFAULT_TAIL_LINES;
+    const allLines: string[] = rawLog.split(/\r?\n/);
+    const truncated: boolean = allLines.length > limit;
+    const shownLines: string[] = truncated ? allLines.slice(-limit) : allLines;
+
+    const header: string =
+      `Log for ${operation.name} (status: ${operation.status}, ${errorsOnly ? 'stderr only' : 'merged'})` +
+      (truncated ? `, showing last ${limit} of ${allLines.length} lines` : '');
+
+    return this._textResult(`${header}\n\n${shownLines.join('\n')}`);
+  }
+
+  private _textResult(text: string): CallToolResult {
+    return {
+      content: [{ type: 'text', text }]
+    };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/build-rebuild.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-rebuild.tool.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { z } from 'zod';
+
+import type { RushServeClient } from '../buildHost/RushServeClient';
+import type { IOperationInfo } from '../buildHost/protocol.types';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+interface IRushRebuildArgs {
+  project: string;
+  phase?: string;
+}
+
+/**
+ * Forces the running Rush build/watch host to rebuild a project's operations by invalidating them,
+ * the same as if their inputs had changed.
+ */
+export class RushRebuildTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_rebuild',
+      description:
+        'Forces the running Rush build/watch host to rebuild a project (optionally a single phase) by ' +
+        'invalidating its operations. Requires a running watch command (e.g. "rush start") with ' +
+        '@rushstack/rush-serve-plugin enabled.',
+      schema: {
+        project: z.string().describe('The npm package name of the project to rebuild.'),
+        phase: z
+          .string()
+          .optional()
+          .describe('Limit the rebuild to this phase (e.g. "_phase:build"). Defaults to all phases.')
+      }
+    });
+    this._client = client;
+  }
+
+  public async executeAsync({ project, phase }: IRushRebuildArgs): Promise<CallToolResult> {
+    await this._client.ensureReadyAsync();
+    const operations: IOperationInfo[] = this._client.findOperations({ project, phase });
+
+    if (operations.length === 0) {
+      return this._textResult(
+        phase
+          ? `No operation found for project "${project}" and phase "${phase}".`
+          : `No operations found for project "${project}".`
+      );
+    }
+
+    const operationNames: string[] = operations.map((operation) => operation.name);
+    await this._client.sendCommandAsync({ command: 'invalidate', operationNames });
+
+    return this._textResult(
+      `Requested rebuild of ${operationNames.length} operation(s):\n` +
+        operationNames
+          .sort()
+          .map((name) => `  ${name}`)
+          .join('\n')
+    );
+  }
+
+  private _textResult(text: string): CallToolResult {
+    return { content: [{ type: 'text', text }] };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/build-shutdown.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-shutdown.tool.ts
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import type { RushServeClient } from '../buildHost/RushServeClient';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+/**
+ * Stops the shared Rush build/watch host daemon. It restarts automatically the next time build status
+ * or logs are requested.
+ */
+export class RushShutdownHostTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_shutdown_host',
+      description:
+        'Stops the shared Rush build/watch host daemon (if running), releasing the repository lock. It ' +
+        'restarts automatically the next time build status or logs are requested.',
+      schema: {}
+    });
+    this._client = client;
+  }
+
+  public async executeAsync(): Promise<CallToolResult> {
+    const stopped: boolean = await this._client.stopDaemonAsync();
+    return {
+      content: [
+        {
+          type: 'text',
+          text: stopped ? 'Stopped the shared build host daemon.' : 'No build host daemon was running.'
+        }
+      ]
+    };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/build-status.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-status.tool.ts
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { z } from 'zod';
+
+import type { IBuildStatusSnapshot, RushServeClient } from '../buildHost/RushServeClient';
+import type { IOperationInfo, ReadableOperationStatus } from '../buildHost/protocol.types';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+/**
+ * Statuses that represent a finished operation that does NOT need attention. Everything else
+ * (failures, warnings, and in-progress work) is surfaced by default to keep the output compact.
+ */
+const SETTLED_OK_STATUSES: ReadonlySet<ReadableOperationStatus> = new Set<ReadableOperationStatus>([
+  'Success',
+  'FromCache',
+  'Skipped',
+  'NoOp'
+]);
+
+interface IRushBuildStatusArgs {
+  project?: string;
+  includeAll?: boolean;
+}
+
+/**
+ * Reports the live status of the running Rush build host (`rush start` + `@rushstack/rush-serve-plugin`)
+ * without the agent needing to run `rush` or read raw build output.
+ */
+export class RushBuildStatusTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_build_status',
+      description:
+        'Reports the current status of the running Rush build/watch host. By default it returns a ' +
+        'compact summary plus only the operations that are failing, warning, or in progress. Requires ' +
+        'a running watch command (e.g. "rush start") with @rushstack/rush-serve-plugin enabled.',
+      schema: {
+        project: z
+          .string()
+          .optional()
+          .describe('Only report operations for this project (npm package name).'),
+        includeAll: z
+          .boolean()
+          .optional()
+          .describe('Include all operations, not just those failing, warning, or in progress.')
+      }
+    });
+    this._client = client;
+  }
+
+  public async executeAsync({ project, includeAll }: IRushBuildStatusArgs): Promise<CallToolResult> {
+    await this._client.ensureReadyAsync();
+    const snapshot: IBuildStatusSnapshot = this._client.getSnapshot();
+
+    let operations: IOperationInfo[] = snapshot.operations.filter((op) => !op.silent);
+    if (project) {
+      operations = operations.filter((op) => op.packageName === project);
+    }
+
+    const counts: Map<ReadableOperationStatus, number> = new Map();
+    for (const op of operations) {
+      counts.set(op.status, (counts.get(op.status) ?? 0) + 1);
+    }
+
+    const shown: IOperationInfo[] = includeAll
+      ? operations
+      : operations.filter((op) => !SETTLED_OK_STATUSES.has(op.status));
+
+    const lines: string[] = [];
+    const { sessionInfo } = snapshot;
+    if (sessionInfo) {
+      lines.push(`Build host: ${sessionInfo.repositoryIdentifier} (command "${sessionInfo.actionName}")`);
+    }
+    lines.push(`Overall status: ${snapshot.overallStatus}`);
+    if (project) {
+      lines.push(`Filtered to project: ${project}`);
+    }
+
+    const countSummary: string = Array.from(counts.entries())
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([status, count]) => `${status}: ${count}`)
+      .join(', ');
+    lines.push(`Operations (${operations.length} total): ${countSummary || 'none'}`);
+    lines.push('');
+
+    if (operations.length === 0) {
+      lines.push(project ? `No operations found for project "${project}".` : 'No operations found.');
+    } else if (shown.length === 0) {
+      lines.push('All operations are settled successfully. Pass includeAll=true to list them.');
+    } else {
+      lines.push(
+        includeAll
+          ? `All ${shown.length} operation(s):`
+          : `${shown.length} operation(s) failing, warning, or in progress:`
+      );
+      for (const op of [...shown].sort((a, b) => a.name.localeCompare(b.name))) {
+        lines.push(`  [${op.status}] ${op.name}${formatDuration(op)}`);
+      }
+    }
+
+    return {
+      content: [{ type: 'text', text: lines.join('\n') }]
+    };
+  }
+}
+
+function formatDuration(op: IOperationInfo): string {
+  // startTime/endTime are not wall-clock times, so only a completed operation yields a meaningful duration.
+  if (op.startTime === undefined || op.endTime === undefined) {
+    return '';
+  }
+  const seconds: number = Math.max(0, (op.endTime - op.startTime) / 1000);
+  return ` (${seconds.toFixed(1)}s)`;
+}

--- a/apps/rush-mcp-server/src/tools/build-watch-state.tool.ts
+++ b/apps/rush-mcp-server/src/tools/build-watch-state.tool.ts
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { z } from 'zod';
+
+import type { RushServeClient } from '../buildHost/RushServeClient';
+import type { IOperationInfo, OperationEnabledState } from '../buildHost/protocol.types';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+interface IRushSetWatchStateArgs {
+  project: string;
+  state: OperationEnabledState;
+  phase?: string;
+}
+
+/**
+ * Turns watching/building on or off for a project's operations in the running Rush build/watch host
+ * by setting their enabled state. Takes effect on the next watch iteration.
+ */
+export class RushSetWatchStateTool extends BaseTool {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
+    super({
+      name: 'rush_set_watch_state',
+      description:
+        "Controls whether the running Rush build/watch host rebuilds a project's operations when changes " +
+        'occur. Use "never" to stop building a project, "default" to restore normal behavior. Takes effect ' +
+        'on the next watch iteration. Requires a running watch command (e.g. "rush start") with ' +
+        '@rushstack/rush-serve-plugin enabled.',
+      schema: {
+        project: z.string().describe('The npm package name of the project.'),
+        state: z
+          .enum(['never', 'changed', 'affected', 'default'])
+          .describe(
+            'never = never build; changed = build only when this project itself changes; ' +
+              'affected = always build when reached; default = restore original behavior.'
+          ),
+        phase: z
+          .string()
+          .optional()
+          .describe('Limit the change to this phase (e.g. "_phase:build"). Defaults to all phases.')
+      }
+    });
+    this._client = client;
+  }
+
+  public async executeAsync({ project, state, phase }: IRushSetWatchStateArgs): Promise<CallToolResult> {
+    await this._client.ensureReadyAsync();
+    const operations: IOperationInfo[] = this._client.findOperations({ project, phase });
+
+    if (operations.length === 0) {
+      return this._textResult(
+        phase
+          ? `No operation found for project "${project}" and phase "${phase}".`
+          : `No operations found for project "${project}".`
+      );
+    }
+
+    const enabledStateByOperationName: Record<string, OperationEnabledState> = {};
+    for (const operation of operations) {
+      enabledStateByOperationName[operation.name] = state;
+    }
+
+    await this._client.sendCommandAsync({ command: 'set-enabled-states', enabledStateByOperationName });
+
+    const names: string[] = Object.keys(enabledStateByOperationName).sort();
+    return this._textResult(
+      `Set watch state to "${state}" for ${names.length} operation(s) (effective next watch iteration):\n` +
+        names.map((name) => `  ${name}`).join('\n')
+    );
+  }
+
+  private _textResult(text: string): CallToolResult {
+    return { content: [{ type: 'text', text }] };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/index.ts
+++ b/apps/rush-mcp-server/src/tools/index.ts
@@ -13,3 +13,4 @@ export { RushRebuildTool } from './build-rebuild.tool';
 export { RushSetWatchStateTool } from './build-watch-state.tool';
 export { RushAbortBuildTool } from './build-abort.tool';
 export { RushRunCommandTool } from './run-command.tool';
+export { RushShutdownHostTool } from './build-shutdown.tool';

--- a/apps/rush-mcp-server/src/tools/index.ts
+++ b/apps/rush-mcp-server/src/tools/index.ts
@@ -7,3 +7,5 @@ export { RushProjectDetailsTool } from './project-details.tool';
 export { RushCommandValidatorTool } from './rush-command-validator.tool';
 export { RushWorkspaceDetailsTool } from './workspace-details';
 export { RushConflictResolverTool } from './conflict-resolver.tool';
+export { RushBuildStatusTool } from './build-status.tool';
+export { RushBuildLogsTool } from './build-logs.tool';

--- a/apps/rush-mcp-server/src/tools/index.ts
+++ b/apps/rush-mcp-server/src/tools/index.ts
@@ -9,3 +9,6 @@ export { RushWorkspaceDetailsTool } from './workspace-details';
 export { RushConflictResolverTool } from './conflict-resolver.tool';
 export { RushBuildStatusTool } from './build-status.tool';
 export { RushBuildLogsTool } from './build-logs.tool';
+export { RushRebuildTool } from './build-rebuild.tool';
+export { RushSetWatchStateTool } from './build-watch-state.tool';
+export { RushAbortBuildTool } from './build-abort.tool';

--- a/apps/rush-mcp-server/src/tools/index.ts
+++ b/apps/rush-mcp-server/src/tools/index.ts
@@ -12,3 +12,4 @@ export { RushBuildLogsTool } from './build-logs.tool';
 export { RushRebuildTool } from './build-rebuild.tool';
 export { RushSetWatchStateTool } from './build-watch-state.tool';
 export { RushAbortBuildTool } from './build-abort.tool';
+export { RushRunCommandTool } from './run-command.tool';

--- a/apps/rush-mcp-server/src/tools/run-command.tool.ts
+++ b/apps/rush-mcp-server/src/tools/run-command.tool.ts
@@ -3,15 +3,25 @@
 
 import { z } from 'zod';
 
+import type { RushServeClient } from '../buildHost/RushServeClient';
 import { CommandRunner, type ICommandResult } from '../utilities/command-runner';
 import { BaseTool, type CallToolResult } from './base.tool';
 
 /**
- * The Rush commands this tool is allowed to run. Restricted to read-only commands that set
- * `safeForSimultaneousRushProcesses` (they skip the repo lock), so they are safe to run alongside a
- * live `rush start` watch. Mutating commands (install/update/add/remove) are intentionally excluded.
+ * The Rush commands this tool is allowed to run. Read-only commands set
+ * `safeForSimultaneousRushProcesses` (they skip the repo lock) and run directly. Mutating commands
+ * acquire the repo lock and rewrite `node_modules`, so they are coordinated with a running watch.
  */
-const ALLOWED_COMMANDS: readonly ['check', 'list'] = ['check', 'list'];
+const ALLOWED_COMMANDS: readonly ['check', 'list', 'install', 'update', 'add', 'remove'] = [
+  'check',
+  'list',
+  'install',
+  'update',
+  'add',
+  'remove'
+];
+
+const MUTATING_COMMANDS: ReadonlySet<string> = new Set(['install', 'update', 'add', 'remove']);
 
 const MAX_OUTPUT_LINES: number = 1000;
 
@@ -31,43 +41,57 @@ function trimOutput(text: string): string {
 }
 
 /**
- * Runs a read-only Rush command in the workspace via the `rush` CLI. Safe to use while a watch is
- * running because the allowed commands do not acquire the repository lock.
+ * Runs an allowed Rush command in the workspace via the `rush` CLI. Read-only commands (`check`,
+ * `list`) are safe alongside a running watch. Mutating commands (`install`, `update`, `add`, `remove`)
+ * need the repository lock, so a watch this server started is stopped first (and restarts on the next
+ * build query); a watch this server did not start causes the command to be refused.
  */
 export class RushRunCommandTool extends BaseTool {
-  public constructor() {
+  private readonly _client: RushServeClient;
+
+  public constructor(client: RushServeClient) {
     super({
       name: 'rush_run_command',
       description:
-        `Runs a read-only Rush command (one of: ${ALLOWED_COMMANDS.join(', ')}) in the workspace and ` +
-        'returns its output. These commands are safe to run alongside a running "rush start" watch ' +
-        'because they do not take the repository lock. Mutating commands (install, update, add, remove) ' +
-        'are not supported by this tool.',
+        `Runs an allowed Rush command (${ALLOWED_COMMANDS.join(', ')}) in the workspace and returns ` +
+        'its output. Read-only commands (check, list) are safe alongside a running watch. Mutating ' +
+        'commands (install, update, add, remove) need the repository lock: if this server started a ' +
+        'watch it is stopped first (and restarts on the next build-status query); if a watch this ' +
+        'server did not start is running, the command is refused so it cannot conflict.',
       schema: {
-        command: z
-          .enum(ALLOWED_COMMANDS)
-          .describe('The Rush command to run. Only read-only commands are allowed.'),
+        command: z.enum(ALLOWED_COMMANDS).describe('The Rush command to run.'),
         args: z
           .array(z.string())
           .optional()
-          .describe('Additional command-line arguments to pass (e.g. ["--json"]).')
+          .describe('Additional command-line arguments to pass (e.g. ["--to", "my-project"]).')
       }
     });
+    this._client = client;
   }
 
   public async executeAsync({ command, args = [] }: IRushRunCommandArgs): Promise<CallToolResult> {
-    // Defense-in-depth: enforce the allowlist in the handler, not only via the input schema, so the
-    // tool never runs an arbitrary (e.g. mutating) Rush command even if invoked outside the schema.
+    // Defense-in-depth: enforce the allowlist in the handler, not only via the input schema.
     if (!(ALLOWED_COMMANDS as readonly string[]).includes(command)) {
-      return {
-        isError: true,
-        content: [
-          {
-            type: 'text',
-            text: `Command "${command}" is not allowed. Allowed read-only commands: ${ALLOWED_COMMANDS.join(', ')}.`
-          }
-        ]
-      };
+      return this._textResult(
+        `Command "${command}" is not allowed. Allowed commands: ${ALLOWED_COMMANDS.join(', ')}.`,
+        true
+      );
+    }
+
+    let notice: string = '';
+    if (MUTATING_COMMANDS.has(command)) {
+      if (this._client.isHostSpawnedByUs()) {
+        await this._client.stopSpawnedHostAsync();
+        notice =
+          'Stopped the build host this server started to free the repository lock; it will restart ' +
+          'on the next build-status query.\n\n';
+      } else if (this._client.isConnected()) {
+        return this._textResult(
+          `Cannot run "rush ${command}" while a build host this server did not start is running ` +
+            `(it holds the repository lock). Stop that watch first, then retry.`,
+          true
+        );
+      }
     }
 
     const result: ICommandResult = await CommandRunner.runRushCommandCaptureAsync([command, ...args]);
@@ -83,6 +107,21 @@ export class RushRunCommandTool extends BaseTool {
       sections.push('', '(no output)');
     }
 
-    return { content: [{ type: 'text', text: sections.join('\n') }] };
+    // If the command bounced off the repo lock, add a hint (e.g. an external watch we never connected to).
+    if (
+      result.status !== 0 &&
+      /Another Rush command is already running/i.test(result.stdout + result.stderr)
+    ) {
+      sections.push(
+        '',
+        'Hint: another Rush process holds the repository lock (likely a watch). Stop it and retry.'
+      );
+    }
+
+    return this._textResult(notice + sections.join('\n'));
+  }
+
+  private _textResult(text: string, isError: boolean = false): CallToolResult {
+    return { isError, content: [{ type: 'text', text }] };
   }
 }

--- a/apps/rush-mcp-server/src/tools/run-command.tool.ts
+++ b/apps/rush-mcp-server/src/tools/run-command.tool.ts
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { z } from 'zod';
+
+import { CommandRunner, type ICommandResult } from '../utilities/command-runner';
+import { BaseTool, type CallToolResult } from './base.tool';
+
+/**
+ * The Rush commands this tool is allowed to run. Restricted to read-only commands that set
+ * `safeForSimultaneousRushProcesses` (they skip the repo lock), so they are safe to run alongside a
+ * live `rush start` watch. Mutating commands (install/update/add/remove) are intentionally excluded.
+ */
+const ALLOWED_COMMANDS: readonly ['check', 'list'] = ['check', 'list'];
+
+const MAX_OUTPUT_LINES: number = 1000;
+
+interface IRushRunCommandArgs {
+  command: (typeof ALLOWED_COMMANDS)[number];
+  args?: string[];
+}
+
+function trimOutput(text: string): string {
+  const lines: string[] = text.split(/\r?\n/);
+  if (lines.length <= MAX_OUTPUT_LINES) {
+    return text;
+  }
+  return `... (showing last ${MAX_OUTPUT_LINES} of ${lines.length} lines)\n${lines
+    .slice(-MAX_OUTPUT_LINES)
+    .join('\n')}`;
+}
+
+/**
+ * Runs a read-only Rush command in the workspace via the `rush` CLI. Safe to use while a watch is
+ * running because the allowed commands do not acquire the repository lock.
+ */
+export class RushRunCommandTool extends BaseTool {
+  public constructor() {
+    super({
+      name: 'rush_run_command',
+      description:
+        `Runs a read-only Rush command (one of: ${ALLOWED_COMMANDS.join(', ')}) in the workspace and ` +
+        'returns its output. These commands are safe to run alongside a running "rush start" watch ' +
+        'because they do not take the repository lock. Mutating commands (install, update, add, remove) ' +
+        'are not supported by this tool.',
+      schema: {
+        command: z
+          .enum(ALLOWED_COMMANDS)
+          .describe('The Rush command to run. Only read-only commands are allowed.'),
+        args: z
+          .array(z.string())
+          .optional()
+          .describe('Additional command-line arguments to pass (e.g. ["--json"]).')
+      }
+    });
+  }
+
+  public async executeAsync({ command, args = [] }: IRushRunCommandArgs): Promise<CallToolResult> {
+    // Defense-in-depth: enforce the allowlist in the handler, not only via the input schema, so the
+    // tool never runs an arbitrary (e.g. mutating) Rush command even if invoked outside the schema.
+    if (!(ALLOWED_COMMANDS as readonly string[]).includes(command)) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text: `Command "${command}" is not allowed. Allowed read-only commands: ${ALLOWED_COMMANDS.join(', ')}.`
+          }
+        ]
+      };
+    }
+
+    const result: ICommandResult = await CommandRunner.runRushCommandCaptureAsync([command, ...args]);
+
+    const sections: string[] = [`$ rush ${[command, ...args].join(' ')}`, `(exit code: ${result.status})`];
+    if (result.stdout.trim()) {
+      sections.push('', '--- stdout ---', trimOutput(result.stdout.trimEnd()));
+    }
+    if (result.stderr.trim()) {
+      sections.push('', '--- stderr ---', trimOutput(result.stderr.trimEnd()));
+    }
+    if (!result.stdout.trim() && !result.stderr.trim()) {
+      sections.push('', '(no output)');
+    }
+
+    return { content: [{ type: 'text', text: sections.join('\n') }] };
+  }
+}

--- a/apps/rush-mcp-server/src/tools/run-command.tool.ts
+++ b/apps/rush-mcp-server/src/tools/run-command.tool.ts
@@ -80,17 +80,11 @@ export class RushRunCommandTool extends BaseTool {
 
     let notice: string = '';
     if (MUTATING_COMMANDS.has(command)) {
-      if (this._client.isHostSpawnedByUs()) {
-        await this._client.stopSpawnedHostAsync();
+      const stopped: boolean = await this._client.stopDaemonAsync();
+      if (stopped) {
         notice =
-          'Stopped the build host this server started to free the repository lock; it will restart ' +
-          'on the next build-status query.\n\n';
-      } else if (this._client.isConnected()) {
-        return this._textResult(
-          `Cannot run "rush ${command}" while a build host this server did not start is running ` +
-            `(it holds the repository lock). Stop that watch first, then retry.`,
-          true
-        );
+          'Stopped the shared build host daemon to free the repository lock; it will restart on the ' +
+          'next build-status query.\n\n';
       }
     }
 

--- a/apps/rush-mcp-server/src/utilities/command-runner.ts
+++ b/apps/rush-mcp-server/src/utilities/command-runner.ts
@@ -5,7 +5,7 @@ import type { ChildProcess } from 'node:child_process';
 
 import { Executable, type IExecutableSpawnSyncOptions } from '@rushstack/node-core-library';
 
-interface ICommandResult {
+export interface ICommandResult {
   status: number;
   stdout: string;
   stderr: string;
@@ -46,7 +46,8 @@ export class CommandRunner {
   private static async _executeCommandAsync(
     command: string,
     args: string[],
-    options?: IExecutableSpawnSyncOptions
+    options?: IExecutableSpawnSyncOptions,
+    allowNonZeroExit: boolean = false
   ): Promise<ICommandResult> {
     const commandPath: string = this._resolveCommand(command);
 
@@ -64,7 +65,7 @@ export class CommandRunner {
       });
 
       childProcess.on('close', (status) => {
-        if (status !== 0) {
+        if (status !== 0 && !allowNonZeroExit) {
           reject(new CommandExecutionError(command, args, stderr, status ?? 1));
           return;
         }
@@ -89,6 +90,18 @@ export class CommandRunner {
     options?: IExecutableSpawnSyncOptions
   ): Promise<ICommandResult> {
     return this._executeCommandAsync('rush', args, options);
+  }
+
+  /**
+   * Runs a `rush` command and resolves with the result regardless of exit code (instead of throwing),
+   * so callers can inspect stdout/stderr/status. Useful for read-only commands like `rush check` that
+   * exit non-zero to signal findings.
+   */
+  public static async runRushCommandCaptureAsync(
+    args: string[],
+    options?: IExecutableSpawnSyncOptions
+  ): Promise<ICommandResult> {
+    return this._executeCommandAsync('rush', args, options, true);
   }
 
   public static async runRushXCommandAsync(

--- a/common/autoinstallers/plugins/package.json
+++ b/common/autoinstallers/plugins/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "dependencies": {
-    "@rushstack/rush-published-versions-json-plugin": "0.1.10"
+    "@rushstack/rush-published-versions-json-plugin": "0.1.10",
+    "@rushstack/rush-serve-plugin": "5.175.1"
   }
 }

--- a/common/autoinstallers/plugins/pnpm-lock.yaml
+++ b/common/autoinstallers/plugins/pnpm-lock.yaml
@@ -11,8 +11,23 @@ importers:
       '@rushstack/rush-published-versions-json-plugin':
         specifier: 0.1.10
         version: 0.1.10
+      '@rushstack/rush-serve-plugin':
+        specifier: 5.175.1
+        version: 5.175.1
 
 packages:
+
+  '@jsep-plugin/assignment@1.3.0':
+    resolution: {integrity: sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
+
+  '@jsep-plugin/regex@1.0.4':
+    resolution: {integrity: sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==}
+    engines: {node: '>= 10.16.0'}
+    peerDependencies:
+      jsep: ^0.4.0||^1.0.0
 
   '@pnpm/lockfile.types@900.0.0':
     resolution: {integrity: sha512-/4+3CAu4uIjx0ln1DYXNdj0qKJ3wyRDY+RS+eFzV6OHjreaTKWsF2WcjigYp1M5mxL4kj2RsRGgBGEyKtCfEWg==}
@@ -28,6 +43,13 @@ packages:
 
   '@rushstack/credential-cache@0.2.17':
     resolution: {integrity: sha512-TSHT0WEiAduX+KbIKZU1IAmTokZzwYF2ErW/4IS5LV2QDaA+uN2jLCKDXmP9D2OxCERwV5OmTb3H6pZZWA+aJg==}
+
+  '@rushstack/debug-certificate-manager@1.7.18':
+    resolution: {integrity: sha512-Dp93F39EwLQTDKqNWACknNwymsGsU57DIwDLbFuUlt15V2hvmDcIFjfGFT9JHEoIQy9MDpNe+VEVc/suffumGg==}
+
+  '@rushstack/heft-config-file@0.20.10':
+    resolution: {integrity: sha512-6UKD7PlaaiLN8tebLMeV8ixm/8NFdmv9biNnPIpHCEEQe8J1TdDDs1HJQ5XGVmIjqljknShPPgDIsHVvVO8ZTw==}
+    engines: {node: '>=10.13.0'}
 
   '@rushstack/lookup-by-path@0.10.6':
     resolution: {integrity: sha512-oxBVdRjaY0r/LwGMESu4rgbWKKnUng8VBD830A3KP5py346WhHbzpMkD9w3Oy75nCqrOTlVWgveL/bW3WVQthw==}
@@ -56,11 +78,17 @@ packages:
       '@types/node':
         optional: true
 
+  '@rushstack/rig-package@0.7.3':
+    resolution: {integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==}
+
   '@rushstack/rush-published-versions-json-plugin@0.1.10':
     resolution: {integrity: sha512-xULrbFQXlHlVv4KXigqdk8Up74WwrzDOki9L360ukMMNYDy20V3dXTwFL08s5dSXiylWOGOrDc54F4USPNFizw==}
 
   '@rushstack/rush-sdk@5.175.1':
     resolution: {integrity: sha512-xdQezHpM/1mJ5SvLpgXCwM6OJqAr9ecoRzQHWjbS3WodC72FfZsAzSNusUazn5qcWFiC5UvaBvBhJAiLJBbvmQ==}
+
+  '@rushstack/rush-serve-plugin@5.175.1':
+    resolution: {integrity: sha512-TEFVVRQGhuBeSFd2pBBvk87ypHkP2t3Zr1zoVsBCWKLb6KGjxn1O4xZdAJrR79AXVL48HpsEEtD12xSxxcIKyQ==}
 
   '@rushstack/terminal@0.24.0':
     resolution: {integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==}
@@ -69,6 +97,16 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@rushstack/ts-command-line@5.3.9':
+    resolution: {integrity: sha512-GIHqU+sRGQ3LGWAZu1O+9Yh++qwtyNIIGuNbcWHJjBTm2qRez0cwINUHZ+pQLR8UuzZDcMajrDaNbUYoaL/XtQ==}
+
+  '@types/argparse@1.0.38':
+    resolution: {integrity: sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -89,22 +127,152 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
+  body-parser@1.20.3:
+    resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  compressible@2.0.18:
+    resolution: {integrity: sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==}
+    engines: {node: '>= 0.6'}
+
+  compression@1.7.5:
+    resolution: {integrity: sha512-bQJ0YRck5ak3LgtnpKkiabX5pNF7tMUh1BSy2ZBOTh0Dim0BUu6aPPwByIns6/A5Prh8PufSPerMDUklpzes2Q==}
+    engines: {node: '>= 0.8.0'}
+
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.6:
+    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
+
+  cookie@0.7.1:
+    resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  destroy@1.0.4:
+    resolution: {integrity: sha512-3NdhDuEXnfun/z7x9GOElY49LoqVHoGScmOKwmxhsS8N5Y+Z8KyPPDnaSzqWgYt/ji4mqwfTS34Htrk0zPIXVg==}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@1.0.2:
+    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
+    engines: {node: '>= 0.8'}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  express@4.21.1:
+    resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
+    engines: {node: '>= 0.10.0'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+  finalhandler@1.3.1:
+    resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
+    engines: {node: '>= 0.8'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -113,20 +281,51 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  http-errors@1.8.1:
+    resolution: {integrity: sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==}
+    engines: {node: '>= 0.6'}
+
+  http-errors@2.0.0:
+    resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
+    engines: {node: '>= 0.8'}
+
+  http2-express-bridge@1.0.7:
+    resolution: {integrity: sha512-bmzZSyn3nuzXRqs/+WgH7IGOQYMCIZNJeqTJ/1AoDgMPTSP5wXQCxPGsdUbGzzxwiHrMwyT4Z7t8ccbsKqiHrw==}
+    engines: {node: '>= 10.0.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   import-lazy@4.0.0:
     resolution: {integrity: sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==}
     engines: {node: '>=8'}
 
-  is-core-module@2.16.1:
-    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
+
+  jsep@1.4.0:
+    resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
+    engines: {node: '>= 10.16.0'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -134,8 +333,106 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jsonpath-plus@10.3.0:
+    resolution: {integrity: sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
+    engines: {node: '>= 6.13.0'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.3.0:
+    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
+    engines: {node: '>= 0.8'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  on-headers@1.0.2:
+    resolution: {integrity: sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==}
+    engines: {node: '>= 0.8'}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@0.1.10:
+    resolution: {integrity: sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.13.0:
+    resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@2.5.2:
+    resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
+    engines: {node: '>= 0.8'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -146,10 +443,62 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  send@0.17.2:
+    resolution: {integrity: sha512-UJYB6wFSJE3G00nEivR5rgWp8c2xXvJ3OPWPhmuteU0IKj8nKbG3DrjiOmLwpnHGYWAVwA69zmTm++YG0Hmwww==}
+    engines: {node: '>= 0.8.0'}
+
+  send@0.19.0:
+    resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
+    engines: {node: '>= 0.8.0'}
+
+  serve-static@1.16.2:
+    resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
+    engines: {node: '>= 0.8.0'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
+  statuses@2.0.1:
+    resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
+    engines: {node: '>= 0.8'}
+
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
 
   supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -163,11 +512,51 @@ packages:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  ws@8.14.2:
+    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
 snapshots:
+
+  '@jsep-plugin/assignment@1.3.0(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
+
+  '@jsep-plugin/regex@1.0.4(jsep@1.4.0)':
+    dependencies:
+      jsep: 1.4.0
 
   '@pnpm/lockfile.types@900.0.0':
     dependencies:
@@ -184,6 +573,23 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@rushstack/debug-certificate-manager@1.7.18':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/terminal': 0.24.0
+      node-forge: 1.4.0
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@rushstack/heft-config-file@0.20.10':
+    dependencies:
+      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/terminal': 0.24.0
+      jsonpath-plus: 10.3.0
+    transitivePeerDependencies:
+      - '@types/node'
+
   '@rushstack/lookup-by-path@0.10.6': {}
 
   '@rushstack/node-core-library@5.23.1':
@@ -191,7 +597,7 @@ snapshots:
       ajv: 8.18.0
       ajv-draft-04: 1.0.0(ajv@8.18.0)
       ajv-formats: 3.0.1(ajv@8.18.0)
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.12
@@ -204,6 +610,11 @@ snapshots:
       - '@types/node'
 
   '@rushstack/problem-matcher@0.2.1': {}
+
+  '@rushstack/rig-package@0.7.3':
+    dependencies:
+      jju: 1.4.0
+      resolve: 1.22.12
 
   '@rushstack/rush-published-versions-json-plugin@0.1.10':
     dependencies:
@@ -225,11 +636,46 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
+  '@rushstack/rush-serve-plugin@5.175.1':
+    dependencies:
+      '@rushstack/debug-certificate-manager': 1.7.18
+      '@rushstack/heft-config-file': 0.20.10
+      '@rushstack/node-core-library': 5.23.1
+      '@rushstack/rig-package': 0.7.3
+      '@rushstack/rush-sdk': 5.175.1
+      '@rushstack/ts-command-line': 5.3.9
+      compression: 1.7.5
+      cors: 2.8.6
+      express: 4.21.1
+      http2-express-bridge: 1.0.7
+      ws: 8.14.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@rushstack/terminal@0.24.0':
     dependencies:
       '@rushstack/node-core-library': 5.23.1
       '@rushstack/problem-matcher': 0.2.1
       supports-color: 8.1.1
+
+  '@rushstack/ts-command-line@5.3.9':
+    dependencies:
+      '@rushstack/terminal': 0.24.0
+      '@types/argparse': 1.0.38
+      argparse: 1.0.10
+      string-argv: 0.3.2
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@types/argparse@1.0.38': {}
+
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
 
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
@@ -242,17 +688,169 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  array-flatten@1.1.1: {}
+
+  body-parser@1.20.3:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.13.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  compressible@2.0.18:
+    dependencies:
+      mime-db: 1.54.0
+
+  compression@1.7.5:
+    dependencies:
+      bytes: 3.1.2
+      compressible: 2.0.18
+      debug: 2.6.9
+      negotiator: 0.6.4
+      on-headers: 1.0.2
+      safe-buffer: 5.2.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
+  content-type@1.0.5: {}
+
+  cookie-signature@1.0.6: {}
+
+  cookie@0.7.1: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
+  depd@1.1.2: {}
+
+  depd@2.0.0: {}
+
+  destroy@1.0.4: {}
+
+  destroy@1.2.0: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@1.0.2: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+
+  escape-html@1.0.3: {}
+
+  etag@1.8.1: {}
+
+  express@4.21.1:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.3
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.1
+      cookie-signature: 1.0.6
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.10
+      proxy-addr: 2.0.7
+      qs: 6.13.0
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.0
+      serve-static: 1.16.2
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
-  fs-extra@11.3.4:
+  finalhandler@1.3.1:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.1
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
+
+  fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
@@ -260,21 +858,77 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
+
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@4.0.0: {}
+
+  has-symbols@1.1.0: {}
 
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
 
+  http-errors@1.8.1:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 1.5.0
+      toidentifier: 1.0.1
+
+  http-errors@2.0.0:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.1
+      toidentifier: 1.0.1
+
+  http2-express-bridge@1.0.7:
+    dependencies:
+      merge-descriptors: 1.0.3
+      send: 0.17.2
+      setprototypeof: 1.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   import-lazy@4.0.0: {}
 
-  is-core-module@2.16.1:
+  inherits@2.0.4: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-core-module@2.16.2:
     dependencies:
       hasown: 2.0.3
 
   jju@1.4.0: {}
+
+  jsep@1.4.0: {}
 
   json-schema-traverse@1.0.0: {}
 
@@ -284,18 +938,175 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonpath-plus@10.3.0:
+    dependencies:
+      '@jsep-plugin/assignment': 1.3.0(jsep@1.4.0)
+      '@jsep-plugin/regex': 1.0.4(jsep@1.4.0)
+      jsep: 1.4.0
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@0.3.0: {}
+
+  merge-descriptors@1.0.3: {}
+
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  negotiator@0.6.3: {}
+
+  negotiator@0.6.4: {}
+
+  node-forge@1.4.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.3.0:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  on-headers@1.0.2: {}
+
+  parseurl@1.3.3: {}
+
   path-parse@1.0.7: {}
+
+  path-to-regexp@0.1.10: {}
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.13.0:
+    dependencies:
+      side-channel: 1.1.0
+
+  range-parser@1.2.1: {}
+
+  raw-body@2.5.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   require-from-string@2.0.2: {}
 
   resolve@1.22.12:
     dependencies:
       es-errors: 1.3.0
-      is-core-module: 2.16.1
+      is-core-module: 2.16.2
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  safe-buffer@5.2.1: {}
+
+  safer-buffer@2.1.2: {}
+
   semver@7.7.4: {}
+
+  send@0.17.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 1.1.2
+      destroy: 1.0.4
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 1.8.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.3.0
+      range-parser: 1.2.1
+      statuses: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
+  send@0.19.0:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 1.0.2
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.0
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.2:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.0
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  sprintf-js@1.0.3: {}
+
+  statuses@1.5.0: {}
+
+  statuses@2.0.1: {}
+
+  string-argv@0.3.2: {}
 
   supports-color@8.1.1:
     dependencies:
@@ -305,4 +1116,19 @@ snapshots:
 
   tapable@2.2.1: {}
 
+  toidentifier@1.0.1: {}
+
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
+
+  vary@1.1.2: {}
+
+  ws@8.14.2: {}

--- a/common/autoinstallers/plugins/rush-plugins/@rushstack/rush-serve-plugin/rush-plugin-manifest.json
+++ b/common/autoinstallers/plugins/rush-plugins/@rushstack/rush-serve-plugin/rush-plugin-manifest.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/rush/v5/rush-plugin-manifest.schema.json",
+  "plugins": [
+    {
+      "pluginName": "rush-serve-plugin",
+      "description": "Rush plugin for serving built files from localhost",
+      "entryPoint": "./lib-commonjs/index.js",
+      "optionsSchema": "./lib-commonjs/schemas/rush-serve-plugin-options.schema.json"
+    }
+  ]
+}

--- a/common/config/rush-plugins/rush-serve-plugin.json
+++ b/common/config/rush-plugins/rush-serve-plugin.json
@@ -1,0 +1,5 @@
+{
+  "phasedCommands": ["start"],
+  "buildStatusWebSocketPath": "/",
+  "logServePath": "/log"
+}

--- a/common/config/rush/rush-plugins.json
+++ b/common/config/rush/rush-plugins.json
@@ -29,6 +29,11 @@
       "packageName": "@rushstack/rush-published-versions-json-plugin",
       "pluginName": "rush-published-versions-json-plugin",
       "autoinstallerName": "plugins"
+    },
+    {
+      "packageName": "@rushstack/rush-serve-plugin",
+      "pluginName": "rush-serve-plugin",
+      "autoinstallerName": "plugins"
     }
   ]
 }

--- a/common/config/subspaces/default/pnpm-lock.yaml
+++ b/common/config/subspaces/default/pnpm-lock.yaml
@@ -430,6 +430,9 @@ importers:
       '@rushstack/ts-command-line':
         specifier: workspace:*
         version: link:../../libraries/ts-command-line
+      ws:
+        specifier: ~8.20.0
+        version: 8.20.0
       zod:
         specifier: ~3.25.76
         version: 3.25.76
@@ -440,6 +443,9 @@ importers:
       '@types/node':
         specifier: 20.17.19
         version: 20.17.19
+      '@types/ws':
+        specifier: 8.5.5
+        version: 8.5.5
       eslint:
         specifier: ~9.37.0
         version: 9.37.0

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -288,3 +288,70 @@ that holds the repo lock once and runs install/update/check via the manager clas
 **Known tensions:** with a shared watch, mutating commands are inherently stop-the-world for all
 attached agents (one of them stops the daemon); 6c should queue/coordinate these. Persistence means
 the daemon must be shut down explicitly or by staleness — orphan management moves into the daemon.
+
+## 12. 6d implementation plan — upstream `rush daemon` (in-process)
+
+The end state: one long-lived process that **holds the repo lock once** and runs both the watch and
+`install`/`update`/`check`/`add` **in-process** via the manager classes — no child `rush start`, no
+lock juggling, and daemon-*mediated* mutating that coordinates with the watch. This is a rush-lib
+*core* change and needs maintainer (pgonzal) buy-in; deliver it as its own PR(s), not bolted onto the
+MCP server.
+
+### Verified seams (symbols confirmed to exist)
+- **install/update:** `doBasicInstallAsync(...)` (`libraries/rush-lib/src/logic/installManager/doBasicInstallAsync.ts`)
+  wraps `InstallManagerFactory.getInstallManagerAsync()` → `BaseInstallManager.doInstallAsync()`.
+- **add/remove:** `PackageJsonUpdater.doRushUpdateAsync(options)` (`logic/PackageJsonUpdater.ts:252`).
+- **check:** `VersionMismatchFinder.rushCheck(rushConfiguration, terminal, options)` (static, lock-free;
+  `logic/versionMismatch/VersionMismatchFinder.ts:69`).
+- **The lock is at the ACTION layer, not the managers:** `LockFile.tryAcquire(commonTempFolder, 'rush')`
+  in `cli/actions/BaseRushAction.ts:68`. A process holding it once can call the managers above directly
+  with no re-lock. ← the load-bearing fact for 6d.
+- **Watch already wants to be long-lived:** `cli/scriptActions/PhasedScriptAction.ts:885` —
+  `// Revisit when migrating to @rushstack/operation-graph and we have a long-lived operation graph`.
+- **Observability reuse:** rush-serve attaches via `rushSession.hooks.runPhasedCommand.for(name).tapPromise`
+  (`pluginFramework/RushLifeCycle.ts:101`), so an in-process phased command can keep the existing WS
+  protocol (and our MCP client) unchanged.
+
+### Sub-increments (each independently shippable + testable)
+- **6d-1 — extract `PhasedCommandRunner` from `PhasedScriptAction`** (pure refactor, no behavior change).
+  Lift `_runInitialPhasesAsync` / `_runWatchPhasesAsync` / `_executeOperationsAsync` + ProjectWatcher
+  wiring into a reusable class not tied to the CLI action; `PhasedScriptAction` becomes a thin wrapper.
+  Expose `runInitialAsync()`, `runWatchLoopAsync(abortSignal)`, and `quiesceAsync()`/`resumeAsync()`
+  (pause ProjectWatcher + cancel in-flight ops + run the `shutdownAsync` hook to stop IPC workers — the
+  `x` keypress already does this) WITHOUT releasing the lock. *Test:* `rush start`/`rush build` behave
+  identically (regression). Land this first — it de-risks everything and is independently useful.
+- **6d-2 — add a `rush daemon` action** that holds the lock (BaseRushAction already holds it for the
+  process lifetime) and hosts the watch via `PhasedCommandRunner` with rush-serve attached. *Test:*
+  the MCP build tools work against `rush daemon` exactly as against `rush start`.
+- **6d-3 — control channel + in-process mutating.** Add a request/response control endpoint (unix
+  socket / named pipe, or extend rush-serve's WS command set with `run-command`). On a mutating
+  request: `quiesceAsync()` the watch → run `doBasicInstallAsync` / `doRushUpdateAsync` / `rushCheck`
+  in-process → `resumeAsync()` (re-snapshot inputs, restart workers). No lock release. *Test (the risky
+  one):* run install repeatedly in one long-lived process — see risks below.
+- **6d-4 — point the MCP at `rush daemon`.** Replace the `rush start` supervisor launch with
+  `rush daemon`; route mutating commands to its control channel instead of stopping the daemon. Keep
+  the discovery file (now also advertising the control endpoint).
+
+### Avoiding the one-shot CLI coupling
+Call the **manager layer**, never the action layer: `InstallAction`/`UpdateAction` etc. carry the
+one-shot semantics (the parser's `_reportErrorAndSetExitCode` calls `process.exit`; `_ensureEnvironment`
+mutates `process.env.PATH`; telemetry flushes on exit; install event hooks fire). The managers
+(`doBasicInstallAsync`, `doRushUpdateAsync`, `rushCheck`) don't lock, don't `process.exit`, and don't
+mutate global PATH — so they're safe to call repeatedly in a daemon. Set PATH once at daemon start;
+flush telemetry on daemon shutdown; decide per-command whether pre/post-install event hooks should run.
+
+### Real risks (validate in 6d-3 before committing)
+- **Long-lived-process assumptions:** Rush is built for one-command-per-process. Running install
+  repeatedly in a daemon may surface stale `require`/module-resolution caches (node_modules changed
+  underneath), cached config singletons, or accumulated listeners. Mitigation: after install, reset
+  module resolution and restart IPC workers (their resolved modules changed) — the same stop-the-world
+  reality as today, but in-process. This is the main thing to prove out empirically.
+- **Error isolation:** a failed install must not tear down the daemon — wrap each in-process command
+  in its own try/catch and surface the error over the control channel.
+- **PhasedScriptAction extraction is invasive** (central, large action) — keep 6d-1 a strict no-op
+  refactor with the existing watch tests as the guardrail.
+
+### Validation strategy
+6d-1: existing `rush start`/`rush build`/`--watch` regression suite. 6d-2: MCP tools vs `rush daemon`.
+6d-3: a harness that issues N installs + builds in one daemon process and asserts correctness +
+no leaks. 6d-4: the multi-agent + mutating flows from §8, now daemon-mediated.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -112,7 +112,7 @@ call these directly in-process without re-acquiring.
 - **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance). ✅ **done, validated via shim**
 - **Phase 6 / Path 2 (chosen)** — `rush daemon`: a persistent supervisor owns one shared watch; see §11.
   - 6a — daemon foundation (supervisor + discovery + graceful shutdown). ✅ **done, validated standalone**
-  - 6b — wire the MCP client to start-or-connect to the daemon (+ shutdown tool). ⏳ next
+  - 6b — wire the MCP client to start-or-connect to the daemon (+ shutdown tool). ✅ **done, validated**
   - 6c — daemon-mediated mutating commands + supervision/auto-restart.
   - 6d — upstream `rush daemon` in rush-lib with in-process managers (no child `rush start`).
 
@@ -210,6 +210,13 @@ noreply email during the first push — see Validation log).
   `common/temp/rushmcp-build-host.json` {webSocketUrl, daemonPid, startedAt}. A raw WS client connected
   to the discovered URL and got `[sync] ops=4 status=Success`. `SIGTERM` to the daemon → discovery
   cleared, watch tree reaped (no orphans) — graceful shutdown confirmed.
+- **Phase 6b live (client wired to daemon, via shim):** client A (a node process) cold-started the
+  daemon and exited; the daemon **persisted** (same pid alive, 1 daemon process). Client B (a separate
+  process) **reused the same daemon** via the discovery file — same pid + URL, still 1 daemon. A
+  mutating `install` stopped the shared daemon (freed the lock, ran at exit 0, no orphan; restarts
+  lazily). `rush_shutdown_host` stopped the daemon (dead, discovery cleared). Client model changed:
+  the client no longer owns the watch (the daemon does); `disposeAsync` is a no-op so the shared host
+  survives MCP exits; mutating commands stop the daemon (any client can) rather than refusing.
 
 ## 9. Running the live test harness (repro)
 

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -113,8 +113,16 @@ call these directly in-process without re-acquiring.
 - **Phase 6 / Path 2 (chosen)** — `rush daemon`: a persistent supervisor owns one shared watch; see §11.
   - 6a — daemon foundation (supervisor + discovery + graceful shutdown). ✅ **done, validated standalone**
   - 6b — wire the MCP client to start-or-connect to the daemon (+ shutdown tool). ✅ **done, validated**
-  - 6c — daemon-mediated mutating commands + supervision/auto-restart.
+  - 6c — auto-restart supervision. ✅ **done, validated**. (Daemon-*mediated* mutating via a control
+    socket: intentionally NOT built — see note below; the current "stop the daemon, run, lazy restart"
+    is correct and composes with supervision, and proper mediation belongs in 6d.)
   - 6d — upstream `rush daemon` in rush-lib with in-process managers (no child `rush start`).
+
+**Why mutating kills the whole daemon (not just its watch):** with supervision, if a client killed only
+the watch to free the lock, the daemon would immediately restart the watch and fight the in-flight
+`install` for the lock. Killing the daemon removes the supervisor cleanly so nothing races the install;
+a fresh daemon starts lazily afterward. Daemon-*mediated* install (daemon pauses supervision → runs →
+resumes) needs a control channel and is the right shape for 6d, not a bespoke socket now.
 
 ## 7. Implementation status
 
@@ -217,6 +225,11 @@ noreply email during the first push — see Validation log).
   lazily). `rush_shutdown_host` stopped the daemon (dead, discovery cleared). Client model changed:
   the client no longer owns the watch (the daemon does); `disposeAsync` is a no-op so the shared host
   survives MCP exits; mutating commands stop the daemon (any client can) rather than refusing.
+- **Phase 6c live (supervision, via shim):** with the daemon serving at port 45731, killed its watch
+  process group to simulate a crash. The daemon logged `Watch exited; restarting...` and came back at a
+  NEW port (34529), same daemon pid, discovery file updated. A client then connected to the restarted
+  watch via discovery (`POST-RESTART: Overall status: Success`). `SIGTERM` → clean shutdown, no orphans.
+  Crash-loop guard: gives up after `MAX_CONSECUTIVE_FAILURES` fast failures.
 
 ## 9. Running the live test harness (repro)
 

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -107,15 +107,16 @@ call these directly in-process without re-acquiring.
 - **Phase 0** — live target + protocol spike. *(done implicitly while validating Phase 1)*
 - **Phase 1** — read-only MCP: observe + logs. ✅ **done, committed, validated live**
 - **Phase 2** — control the watch (rebuild / set-watch-state / abort). ✅ **done, validated live**
-- **Phase 3** — read-only rush commands (check/list/change/scan) via shell-out.
+- **Phase 3** — read-only rush commands (check/list) via shell-out. ✅ **done, validated via shim**
 - **Phase 4** — spawn-or-connect (stop requiring a pre-started watch).
 - **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance).
 - **Phase 6** — multi-agent sharing + robustness (discovery file, race-safe spawn) → Path-2 decision.
 
 ## 7. Implementation status
 
-Branch `nickpape/mcp-build-host-tools`. Phase 1 committed as `93ff2f453c`. Phase 2 implemented,
-compiles green, validated live — **not yet committed**.
+Branch `nickpape/mcp-build-host-tools`, pushed to the fork as **in-fork PR #20**
+(`nick-pape/rushstack` main ← branch). Phases 1–3 committed (commit hashes were rewritten to the
+noreply email during the first push — see Validation log).
 
 **Tools (all in `@rushstack/mcp-server`, sharing one lazy `RushServeClient`):**
 - `rush_build_status` — compact: host id, overall status, status counts, only non-green ops; `project`
@@ -125,6 +126,9 @@ compiles green, validated live — **not yet committed**.
 - `rush_rebuild` — invalidate a project's operations (force rebuild).
 - `rush_set_watch_state` — set enabled state (never|changed|affected|default) per project/phase.
 - `rush_abort_build` — abort the current execution pass.
+- `rush_run_command` — run a read-only Rush command (allowlist: `check`, `list`) via shell-out;
+  allowlist enforced in BOTH the input schema and the handler. Uses
+  `CommandRunner.runRushCommandCaptureAsync` (resolves with output regardless of exit code).
 
 **File inventory:**
 - `apps/rush-mcp-server/src/buildHost/protocol.types.ts` — local mirror of rush-serve `/api` (events + commands).
@@ -158,6 +162,17 @@ compiles green, validated live — **not yet committed**.
   iteration so control tools work immediately.
 - **rush-serve behavior #2 (coalescing):** an `invalidate` sent while a build is in-flight folds into
   the running build (no separate cycle).
+- **Phase 3 live (via shim):** `rush` isn't on PATH in the sandbox; tested with a `rush` shim that
+  delegates to `common/scripts/install-run-rush.js`. `rush list` / `rush check` return real output
+  (exit 0). **Defense-in-depth finding:** enforce the allowlist *in the handler*, not only via the zod
+  schema — calling `executeAsync` directly bypasses schema validation (a direct call accidentally ran
+  `rush install`, which bailed at the git-email policy before changing anything).
+- **PR/push gotchas:** GitHub blocked the push (private email) → rewrote the commits to
+  `5674316+nick-pape@users.noreply.github.com` via `git filter-branch` (`rebase --exec --reset-author`
+  did NOT take — rebase re-exports the original author env). `gh pr create` failed under SAML because it
+  reads the upstream parent (microsoft/rushstack); created the PR via
+  `gh api repos/nick-pape/rushstack/pulls` instead. Commit with inline
+  `-c user.email='5674316+nick-pape@users.noreply.github.com' -c user.name='Nick Pape'`.
 
 ## 9. Running the live test harness (repro)
 
@@ -177,8 +192,6 @@ Wired into THIS repo for validation (kept uncommitted — it's a harness, not th
 
 ## 10. Open questions / next steps
 
-- Commit Phase 2 (feature files only)?
-- Phase 3: read-only `rush check`/`list` via the existing `CommandRunner` shell-out.
 - Cold-watch handling (behavior #1) — surface state or auto-warm?
 - Discovery / spawn-or-connect (Phase 4): rush-serve has no discovery file; likely add one
   (port + wsPath + logServePath + repoId + pid), upstream-able.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -355,3 +355,46 @@ flush telemetry on daemon shutdown; decide per-command whether pre/post-install 
 6d-1: existing `rush start`/`rush build`/`--watch` regression suite. 6d-2: MCP tools vs `rush daemon`.
 6d-3: a harness that issues N installs + builds in one daemon process and asserts correctness +
 no leaks. 6d-4: the multi-agent + mutating flows from §8, now daemon-mediated.
+
+### 6d execution log — keystone spike (2026-05-21)
+
+Tried to de-risk the load-bearing assumption ("can a long-lived process hold the 'rush' lock once and
+run install in-process, twice?") with a throwaway external spike before touching core. It surfaced two
+hard constraints that **redirect** 6d — exactly what de-risking-first is for:
+
+1. **rush-lib ships as a webpack bundle** (`@rushstack/webpack-deep-imports-plugin`). The
+   `lib-commonjs/*` files are stubs that resolve through the bundle runtime; you cannot `require` an
+   internal module standalone (fails with a numeric `__webpack_require__('NNNN')` MODULE_NOT_FOUND).
+2. **No external in-process shortcut to the managers.** rush-sdk's `RushSdkLoader` loads the repo's
+   *published* Rush (from `common/temp/install-run/@microsoft+rush@<ver>`), not local source, and
+   `RushInternals.loadModule` (a thin `require()` wrapper, not an allowlist) on
+   `logic/installManager/doBasicInstallAsync` throws *"not implemented by Rush 5.175.1"* (the path
+   isn't loadable in the published bundle / version skew).
+
+**Conclusion (evidence-backed):** in-process `install`/`update` cannot be driven from an external
+daemon via rush-sdk. 6d's in-process model **must** be implemented *inside* rush-lib — a real
+`rush daemon` action that calls `doBasicInstallAsync` as a same-bundle call (exactly how `InstallAction`
+already does every run). The genuinely-novel risk (the *same* process running install **twice**) can
+therefore only be validated from inside rush-lib; it remains open.
+
+**Why this wasn't slammed out here:** the remaining 6d work is a rush-lib *core* change (extract the
+watch engine from `PhasedScriptAction` + add a `rush daemon` action). Its only safe guardrail is
+rush-lib's full test suite + the `rush build`/`rush start`/`--watch` regression matrix — not runnable
+end-to-end in this session. Landing a 1196-line central-action refactor "by vibes" would risk silently
+breaking `rush build` for the whole repo (incl. our own daemon harness). Engineering-sense call: do it
+as a dedicated, test-guarded upstream PR.
+
+### 6d-1 extraction surface (turnkey for that PR)
+
+`PhasedScriptAction` (1196 lines) splits into: **(a) the CLI action** — keeps the constructor's
+~20 `CommandLineParameter` fields + `runAsync` parameter parsing and the build of
+`ICreateOperationsContext`/execution options; and **(b) a reusable `PhasedCommandRunner`** — receives
+the resolved config (phases, resolved project selection, parallelism, terminal, hooks, abort
+controllers, build-cache config, `getInputsSnapshotAsync`) and owns the engine:
+`_runInitialPhasesAsync` (646), `_registerWatchModeInterface` (725), `_runWatchPhasesAsync` (824),
+`_executeOperationsAsync` (970), `_doBeforeTask` (1172), `_doAfterTask` (1186), plus the
+`ProjectWatcher` wiring. It must expose `runInitialAsync()`, `runWatchLoopAsync(abortSignal)`, and
+`quiesceAsync()`/`resumeAsync()` (pause ProjectWatcher + cancel in-flight ops + run the `shutdownAsync`
+hook) **without releasing the 'rush' lock**. `PhasedScriptAction` becomes a thin wrapper; the new
+`rush daemon` action constructs a `PhasedCommandRunner` directly. Guardrail: existing watch tests +
+`rush build`/`start` behave identically.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -109,7 +109,7 @@ call these directly in-process without re-acquiring.
 - **Phase 2** — control the watch (rebuild / set-watch-state / abort). ✅ **done, validated live**
 - **Phase 3** — read-only rush commands (check/list) via shell-out. ✅ **done, validated via shim**
 - **Phase 4** — spawn-or-connect (stop requiring a pre-started watch). ✅ **done, validated via shim**
-- **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance).
+- **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance). ✅ **done, validated via shim**
 - **Phase 6** — multi-agent sharing + robustness (discovery file, race-safe spawn) → Path-2 decision.
 
 ## 7. Implementation status
@@ -126,9 +126,11 @@ noreply email during the first push — see Validation log).
 - `rush_rebuild` — invalidate a project's operations (force rebuild).
 - `rush_set_watch_state` — set enabled state (never|changed|affected|default) per project/phase.
 - `rush_abort_build` — abort the current execution pass.
-- `rush_run_command` — run a read-only Rush command (allowlist: `check`, `list`) via shell-out;
-  allowlist enforced in BOTH the input schema and the handler. Uses
-  `CommandRunner.runRushCommandCaptureAsync` (resolves with output regardless of exit code).
+- `rush_run_command` — run an allowed Rush command via shell-out (allowlist enforced in BOTH the
+  schema and the handler; uses `CommandRunner.runRushCommandCaptureAsync`, output regardless of exit
+  code). Read-only (`check`, `list`) run directly. **Mutating** (`install`, `update`, `add`, `remove`)
+  need the repo lock: if we started the watch, it is stopped first (restarts lazily on next build
+  query); if a watch we did NOT start is connected, the command is refused.
 
 **File inventory:**
 - `apps/rush-mcp-server/src/buildHost/protocol.types.ts` — local mirror of rush-serve `/api` (events + commands).
@@ -194,6 +196,11 @@ noreply email during the first push — see Validation log).
   Stray-process cleanup during testing, BY PID (do NOT `pkill -f` patterns that also match your own
   shell — that kills the build): `for p in $(ps -eo pid,args | grep 'rush start' | grep -v grep |
   awk '{print $1}'); do kill -9 $p; done` and `rm -f common/temp/rush#*.lock`.
+- **Phase 5 live (via shim):** `rush_run_command` read-only `list` ran directly (exit 0); a mutating
+  `install` while our watch was running stopped the watch (freeing the lock), ran `rush install`
+  (exit 0), and left no orphan — `isHostSpawnedByUs` went true→false. The external-watch refusal branch
+  (`isConnected && !isHostSpawnedByUs`) is trivial logic and was not stood up as a separate e2e.
+  Note: `rush install` needs `--bypass-policy` in this repo (git-email policy); real users won't.
 
 ## 9. Running the live test harness (repro)
 

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -135,8 +135,9 @@ noreply email during the first push — see Validation log).
 - `apps/rush-mcp-server/src/buildHost/RushServeClient.ts` — lazy wss client, in-memory snapshot,
   `findOperations`, `sendCommandAsync`, https log fetch (`undefined` on 404), and **spawn-or-connect**:
   tries the configured URL, and if unreachable + autostart, spawns the start command, scrapes the
-  ephemeral port from its stdout, and connects. Spawns detached and kills the process group on
-  dispose/exit. TLS via `rejectUnauthorized:false` (TODO: trust the debug CA).
+  ephemeral port from its stdout, and connects. The host is terminated via `SubprocessTerminator`
+  (whole-tree kill) on dispose and on process exit/SIGINT/SIGTERM. TLS via `rejectUnauthorized:false`
+  (TODO: trust the debug CA).
   Env config (all **`RUSHMCP_`**-prefixed — NOT `RUSH_`, see gotcha below):
   `RUSHMCP_BUILD_STATUS_WS_URL` (default `wss://localhost:8443/`), `RUSHMCP_BUILD_AUTOSTART`
   (default on), `RUSHMCP_BUILD_START_COMMAND` (default `rush start`), `RUSHMCP_BUILD_START_TIMEOUT_MS`.
@@ -184,14 +185,15 @@ noreply email during the first push — see Validation log).
   Rush" → exit 1). Our config vars were originally `RUSH_BUILD_*`; renamed to `RUSHMCP_*`, and the
   spawn also strips `RUSHMCP_*` from the child env. (Don't squat on Rush's namespace — also an
   upstream-review concern.)
-- **Reaping limitation:** spawn-detached + kill-process-group works when our cleanup runs. The sandbox
-  `install-run-rush.js` shim spawns the *real* rush in its own group, so if the parent dies abruptly
-  (e.g. SIGKILL, or a `| head` EPIPE during testing) the real rush is orphaned (reparented to init)
-  and keeps the repo lock → next `rush start` fails with "Another Rush command is already running."
-  In production the global `rush` launcher runs in-process (single tree), so this is mostly a sandbox
-  artifact; for robustness consider `SubprocessTerminator` from `@rushstack/node-core-library`.
-  Cleanup during testing: `pkill -f 'install-run/@microsoft\+rush.*rush start'` and
-  `rm -f common/temp/rush#*.lock`.
+- **Reaping (hardened):** the client now terminates the spawned host with `SubprocessTerminator`
+  (`@rushstack/node-core-library`): spawn with `RECOMMENDED_OPTIONS` (detached on POSIX),
+  `killProcessTreeOnExit` to reap on our exit/SIGINT/SIGTERM, and `killProcessTree` (SIGKILL of the
+  group on POSIX, `TaskKill /T` on Windows) on dispose. Verified: after dispose, no orphaned
+  `rush start` remains and the repo lock is released — even through the `install-run` shim tree.
+  (Caveat: if our process is `kill -9`'d, nothing can run cleanup; that's inherent.)
+  Stray-process cleanup during testing, BY PID (do NOT `pkill -f` patterns that also match your own
+  shell — that kills the build): `for p in $(ps -eo pid,args | grep 'rush start' | grep -v grep |
+  awk '{print $1}'); do kill -9 $p; done` and `rm -f common/temp/rush#*.lock`.
 
 ## 9. Running the live test harness (repro)
 
@@ -218,6 +220,5 @@ Wired into THIS repo for validation (kept uncommitted — it's a harness, not th
 - Phase 6 (multi-agent sharing): a discovery file so a second MCP can find a watch the first one
   spawned (rush-serve uses an ephemeral port with no discovery today); likely add
   port + wsPath + logServePath + repoId + pid, upstream-able. Race-safe spawn (LockFile).
-- Reaping hardening: `SubprocessTerminator` instead of process-group kill (see §8).
 - TLS hardening: trust the debug CA instead of `rejectUnauthorized:false`.
 - Whether to commit the rush-serve test harness or document it as setup.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -110,7 +110,11 @@ call these directly in-process without re-acquiring.
 - **Phase 3** — read-only rush commands (check/list) via shell-out. ✅ **done, validated via shim**
 - **Phase 4** — spawn-or-connect (stop requiring a pre-started watch). ✅ **done, validated via shim**
 - **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance). ✅ **done, validated via shim**
-- **Phase 6** — multi-agent sharing + robustness (discovery file, race-safe spawn) → Path-2 decision.
+- **Phase 6 / Path 2 (chosen)** — `rush daemon`: a persistent supervisor owns one shared watch; see §11.
+  - 6a — daemon foundation (supervisor + discovery + graceful shutdown). ✅ **done, validated standalone**
+  - 6b — wire the MCP client to start-or-connect to the daemon (+ shutdown tool). ⏳ next
+  - 6c — daemon-mediated mutating commands + supervision/auto-restart.
+  - 6d — upstream `rush daemon` in rush-lib with in-process managers (no child `rush start`).
 
 ## 7. Implementation status
 
@@ -201,6 +205,11 @@ noreply email during the first push — see Validation log).
   (exit 0), and left no orphan — `isHostSpawnedByUs` went true→false. The external-watch refusal branch
   (`isConnected && !isHostSpawnedByUs`) is trivial logic and was not stood up as a separate e2e.
   Note: `rush install` needs `--bypass-policy` in this repo (git-email policy); real users won't.
+- **Phase 6a live (daemon foundation, via shim):** ran `node lib-commonjs/daemon/start.js <repo>`; it
+  spawned the watch, scraped the port, printed `Build host ready at wss://localhost:33309/` and wrote
+  `common/temp/rushmcp-build-host.json` {webSocketUrl, daemonPid, startedAt}. A raw WS client connected
+  to the discovered URL and got `[sync] ops=4 status=Success`. `SIGTERM` to the daemon → discovery
+  cleared, watch tree reaped (no orphans) — graceful shutdown confirmed.
 
 ## 9. Running the live test harness (repro)
 
@@ -229,3 +238,33 @@ Wired into THIS repo for validation (kept uncommitted — it's a harness, not th
   port + wsPath + logServePath + repoId + pid, upstream-able. Race-safe spawn (LockFile).
 - TLS hardening: trust the debug CA instead of `rejectUnauthorized:false`.
 - Whether to commit the rush-serve test harness or document it as setup.
+
+## 11. `rush daemon` (Path 2) design
+
+Chosen over the "MCP spawns a persistent watch" hack: a dedicated supervisor process owns the shared
+watch, so its lifecycle is independent of any one MCP client.
+
+**Topology (current increment).** A long-lived `BuildHostDaemon` process (singleton via a
+`rushmcp-daemon` LockFile) supervises one `rush start` + rush-serve watch (reused as the watch
+engine), discovers its ephemeral port, and advertises it in `common/temp/rushmcp-build-host.json`.
+MCP clients read that file and connect to the watch's WebSocket directly (reusing Phases 1–2). The
+watch is reaped when the *daemon* exits (SubprocessTerminator), not when a client exits → it survives
+and is shared across agents.
+
+**Lifecycle.** Client need-a-host flow becomes: configured URL → discovery file → else start the
+daemon (detached, un-reaped, persistent) and wait for discovery. Mutating commands: a client stops
+the daemon (it knows `daemonPid`) to free the lock, runs the command, and the daemon restarts lazily
+on the next build query. The daemon is stopped explicitly (a `rush_shutdown_host` tool) — it is NOT
+reaped on client exit.
+
+**Files:** `src/daemon/discoveryFile.ts` (read/write/validate; staleness = daemon pid dead),
+`src/daemon/BuildHostDaemon.ts` (supervisor), `src/daemon/start.ts` (entrypoint).
+
+**Increments:** 6a foundation ✅ · 6b client start-or-connect + shutdown tool · 6c daemon-mediated &
+queued mutating commands + auto-restart supervision · 6d the real upstream `rush daemon` in rush-lib
+that holds the repo lock once and runs install/update/check via the manager classes **in-process**
+(no child `rush start`), per the action-vs-manager lock seam in §5.
+
+**Known tensions:** with a shared watch, mutating commands are inherently stop-the-world for all
+attached agents (one of them stops the daemon); 6c should queue/coordinate these. Persistence means
+the daemon must be shut down explicitly or by staleness — orphan management moves into the daemon.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -108,7 +108,7 @@ call these directly in-process without re-acquiring.
 - **Phase 1** — read-only MCP: observe + logs. ✅ **done, committed, validated live**
 - **Phase 2** — control the watch (rebuild / set-watch-state / abort). ✅ **done, validated live**
 - **Phase 3** — read-only rush commands (check/list) via shell-out. ✅ **done, validated via shim**
-- **Phase 4** — spawn-or-connect (stop requiring a pre-started watch).
+- **Phase 4** — spawn-or-connect (stop requiring a pre-started watch). ✅ **done, validated via shim**
 - **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance).
 - **Phase 6** — multi-agent sharing + robustness (discovery file, race-safe spawn) → Path-2 decision.
 
@@ -133,9 +133,13 @@ noreply email during the first push — see Validation log).
 **File inventory:**
 - `apps/rush-mcp-server/src/buildHost/protocol.types.ts` — local mirror of rush-serve `/api` (events + commands).
 - `apps/rush-mcp-server/src/buildHost/RushServeClient.ts` — lazy wss client, in-memory snapshot,
-  `findOperations`, `sendCommandAsync`, https log fetch (`undefined` on 404). URL via
-  `RUSH_BUILD_STATUS_WS_URL` (default `wss://localhost:8443/`); TLS via `rejectUnauthorized:false`
-  (TODO: trust the debug CA).
+  `findOperations`, `sendCommandAsync`, https log fetch (`undefined` on 404), and **spawn-or-connect**:
+  tries the configured URL, and if unreachable + autostart, spawns the start command, scrapes the
+  ephemeral port from its stdout, and connects. Spawns detached and kills the process group on
+  dispose/exit. TLS via `rejectUnauthorized:false` (TODO: trust the debug CA).
+  Env config (all **`RUSHMCP_`**-prefixed — NOT `RUSH_`, see gotcha below):
+  `RUSHMCP_BUILD_STATUS_WS_URL` (default `wss://localhost:8443/`), `RUSHMCP_BUILD_AUTOSTART`
+  (default on), `RUSHMCP_BUILD_START_COMMAND` (default `rush start`), `RUSHMCP_BUILD_START_TIMEOUT_MS`.
 - `apps/rush-mcp-server/src/tools/build-status.tool.ts`, `build-logs.tool.ts`, `build-rebuild.tool.ts`,
   `build-watch-state.tool.ts`, `build-abort.tool.ts`.
 - Wired in `src/server.ts` + `src/tools/index.ts`. Added deps `ws ~8.20.0` + `@types/ws 8.5.5`.
@@ -173,6 +177,21 @@ noreply email during the first push — see Validation log).
   reads the upstream parent (microsoft/rushstack); created the PR via
   `gh api repos/nick-pape/rushstack/pulls` instead. Commit with inline
   `-c user.email='5674316+nick-pape@users.noreply.github.com' -c user.name='Nick Pape'`.
+- **Phase 4 live (via shim):** with the configured port free, the client auto-started
+  `rush start`, scraped its ephemeral port from stdout, connected, and returned status (~1.4s when cached).
+- **MAJOR gotcha — reserved `RUSH_` prefix:** the spawned `rush` inherits the parent env, and Rush
+  **errors out on any unrecognized `RUSH_`-prefixed variable** ("not recognized by this version of
+  Rush" → exit 1). Our config vars were originally `RUSH_BUILD_*`; renamed to `RUSHMCP_*`, and the
+  spawn also strips `RUSHMCP_*` from the child env. (Don't squat on Rush's namespace — also an
+  upstream-review concern.)
+- **Reaping limitation:** spawn-detached + kill-process-group works when our cleanup runs. The sandbox
+  `install-run-rush.js` shim spawns the *real* rush in its own group, so if the parent dies abruptly
+  (e.g. SIGKILL, or a `| head` EPIPE during testing) the real rush is orphaned (reparented to init)
+  and keeps the repo lock → next `rush start` fails with "Another Rush command is already running."
+  In production the global `rush` launcher runs in-process (single tree), so this is mostly a sandbox
+  artifact; for robustness consider `SubprocessTerminator` from `@rushstack/node-core-library`.
+  Cleanup during testing: `pkill -f 'install-run/@microsoft\+rush.*rush start'` and
+  `rm -f common/temp/rush#*.lock`.
 
 ## 9. Running the live test harness (repro)
 
@@ -185,15 +204,20 @@ Wired into THIS repo for validation (kept uncommitted — it's a harness, not th
    alone gives "Manifest not found"; `--bypass-policy` skips this repo's git-email policy).
 5. `rush start --only @rushstack/tree-pattern` (small prebuilt project). It prints
    `Content is being served from: https://localhost:<PORT>/`.
-6. Point the client at it: `RUSH_BUILD_STATUS_WS_URL=wss://localhost:<PORT>/` and call the built tools
+6. Point the client at it: `RUSHMCP_BUILD_STATUS_WS_URL=wss://localhost:<PORT>/` and call the built tools
    in `apps/rush-mcp-server/lib-commonjs/...`.
-- Git identity isn't set in this repo; commit with inline
-  `-c user.email=nickpape@outlook.com -c user.name="Nick Pape"`. Pre-commit hook runs `rush prettier`.
+- Git identity: the env sets `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL` to the private address, which
+  **overrides `-c user.email`**. GitHub blocks pushing the private email, so commit with the env vars
+  overridden, e.g. prefix with
+  `GIT_AUTHOR_EMAIL=5674316+nick-pape@users.noreply.github.com GIT_COMMITTER_EMAIL=5674316+nick-pape@users.noreply.github.com`.
+  Pre-commit hook runs `rush prettier`.
 
 ## 10. Open questions / next steps
 
 - Cold-watch handling (behavior #1) — surface state or auto-warm?
-- Discovery / spawn-or-connect (Phase 4): rush-serve has no discovery file; likely add one
-  (port + wsPath + logServePath + repoId + pid), upstream-able.
+- Phase 6 (multi-agent sharing): a discovery file so a second MCP can find a watch the first one
+  spawned (rush-serve uses an ephemeral port with no discovery today); likely add
+  port + wsPath + logServePath + repoId + pid, upstream-able. Race-safe spawn (LockFile).
+- Reaping hardening: `SubprocessTerminator` instead of process-group kill (see §8).
 - TLS hardening: trust the debug CA instead of `rejectUnauthorized:false`.
 - Whether to commit the rush-serve test harness or document it as setup.

--- a/rush-ipc-mcp-findings.md
+++ b/rush-ipc-mcp-findings.md
@@ -1,0 +1,186 @@
+# rush-ipc-mcp — findings & design log
+
+A living document for the effort to expose a running Rush build/watch host to agents via MCP.
+Update this as work proceeds (append to the Validation log; revise sections in place).
+
+Owner: nickpape · Started 2026-05-21
+
+---
+
+## 1. Goal & motivation
+
+Let agents observe and control a Rush build **without running `rush` directly**, because direct
+invocation is: (A) token-wasteful, (B) breaks with parallel agents (they fight the repo lock),
+(C) not visible, (D) impossible without giving the agent a shell.
+
+Originally conceived as a standalone `rush-ipc-mcp`; refined to a feature **inside the existing
+`@rushstack/mcp-server`** (first-class tools, not the disliked plugin framework — also the
+upstream-friendly / "makes Pete happy" path).
+
+## 2. Architecture decisions
+
+- **Topology = wrap rush-serve.** The long-lived build host is `rush start` running
+  `@rushstack/rush-serve-plugin`, which already exposes an HTTP/2 + WebSocket server. The MCP is a
+  thin Layer-2 client that connects to that WebSocket and re-exposes it as MCP tools. Each agent gets
+  its own short-lived stdio MCP process; all share one `rush start`.
+- **Code location = extend `apps/rush-mcp-server`** with first-class tools (cohesive `buildHost/`
+  subfolder, easy to relocate). Not a new Rush package; not an MCP plugin.
+- **v1 scope = observe + control watch + logs + run rush cmds.**
+
+## 3. How Rush's "IPC" actually works (two layers)
+
+Rush's built-in "IPC" is **not** a daemon you connect to. It's parent→child worker lifecycle within
+one `rush <cmd> --watch` process (the host).
+
+- **Layer 1 — host ↔ worker** (Node `child_process` fork IPC, stdio includes `'ipc'`):
+  protocol in `libraries/operation-graph/src/protocol.types.ts`. Host→worker: run/cancel/exit/sync.
+  Worker→host: sync/requestRun/after-execute. Worker side = `WatchLoop.runIPCAsync()`
+  (`libraries/operation-graph/src/WatchLoop.ts`); host side = `IPCOperationRunner` +
+  `IPCOperationRunnerPlugin` (`libraries/rush-lib/src/logic/operations/`). Keeps per-`project#phase`
+  build tools warm across rebuilds. Gated by experiment `useIPCScriptsInWatchMode` + `--no-ipc`;
+  fires only for projects with `<phase>:ipc` / `<phase>:incremental:ipc` scripts. Carries
+  `OperationStatus`, not logs (logs flow over stdout/stderr).
+- **Layer 2 — host ↔ observer** (WebSocket): `rush-plugins/rush-serve-plugin` taps host hooks
+  (createOperations / beforeExecuteOperations / onOperationStatusChanged / afterExecuteOperations)
+  and rebroadcasts. **This is the observability + control plane our MCP consumes.**
+
+Watch control today (TTY only) lives in `PhasedScriptAction._registerWatchModeInterface`: keys
+`q` quit, `a` abort, `w` pause/resume, `i` invalidate-all, `c` changed-only, `b` build-once,
+`x` reset child procs. Not programmatic. Per-project granularity = invalidate, not subscribe.
+
+Logs/state on disk: `<project>/.rush/operations/<phase>/*.log` (+ `.error.log`, jsonl);
+timing/cobuild in `.rush/temp/operation/<phase>/state.json`.
+
+rush-lib's public API is model/config-centric; the CLI **actions** (install/build managers) are NOT
+exported. External tools load via `@rushstack/rush-sdk` (supports deep imports
+`@rushstack/rush-sdk/lib/...`).
+
+## 4. rush-serve WebSocket protocol (Layer-2, what we consume)
+
+Source of truth: `rush-plugins/rush-serve-plugin/src/api.types.ts` (types-only entrypoint
+`@rushstack/rush-serve-plugin/api`). We keep a local mirror at
+`apps/rush-mcp-server/src/buildHost/protocol.types.ts` to avoid a runtime dep — keep them in sync.
+
+- **Server→client events:** `sync` (full ops + sessionInfo + overall status, on connect/request),
+  `before-execute` (ops at pass start), `status-change` (batched per-op deltas, debounced via
+  setImmediate), `after-execute` (ops + overall status).
+- **Client→server commands:** `sync`, `invalidate {operationNames}`, `abort-execution`,
+  `set-enabled-states {name → never|changed|affected|default}`.
+- **`IOperationInfo`:** name, dependencies[], packageName, phaseName, enabled, silent, noop, status
+  (PascalCase), logFileURLs {text,error,jsonl} (serve-relative), startTime, endTime
+  (**not wall-clock — only completed ops yield a meaningful duration**).
+- Transport: HTTP/2 secure server with a self-signed debug cert (`CertificateManager`); ephemeral
+  port unless a `portParameterLongName` is configured. Logs served as static files at `logServePath`.
+- **Lives inside `rush start`; dies with it.** Not a cross-invocation daemon — persistence is still
+  ours to add (later phase).
+
+## 5. Locking model & the install/build coordination problem
+
+Decisive constraint, confirmed in code: repo-wide lock `'rush'` in `commonTempFolder`, acquired
+non-blocking (`LockFile.tryAcquire`) in `BaseConfiglessRushAction.onExecuteAsync()`
+(`libraries/rush-lib/src/cli/actions/BaseRushAction.ts` ~line 68). Held for the **whole command**
+(released on process exit). On contention: prints "Another Rush command is already running" and
+`process.exit(1)` — instant, doesn't queue. Skipped by `safeForSimultaneousRushProcesses=true`:
+**check, change, deploy, list, scan** (read-only, runnable alongside a watch).
+
+Therefore:
+- Read-only commands → shell out anytime, even during a watch.
+- Mutating commands (install/update/add/remove) are blocked by the lock AND inherently stop-the-world
+  (they rewrite node_modules under a running build).
+
+**Key seam:** the lock is at the **action** layer, not the **manager** layer. Reusable, CLI-decoupled
+entry points exist: install/update → `InstallManagerFactory.getInstallManagerAsync()` →
+`installManager.doInstallAsync()`; add/remove → `PackageJsonUpdater.doRushUpdateAsync()`; check →
+`VersionMismatchFinder.rushCheck()` (static, already lock-free). A daemon that holds the lock once can
+call these directly in-process without re-acquiring.
+
+**Two paths for "run other rush commands":**
+- **Path 1 (stopgap, current direction):** wrap `rush start`; shell out read-only cmds; for install do
+  a coarse stop-watch → install → relaunch (loses warm workers).
+- **Path 2 (the `rush daemon` refactor):** a first-class long-lived process that owns the lock once,
+  hosts the watch (operation-graph + ProjectWatcher + rush-serve WS), and runs install/update/check/add
+  in-process via the manager classes, serializing internally. Aligns with the existing "long-lived
+  operation graph" TODOs in `PhasedScriptAction` / `IPCOperationRunnerPlugin`; upstream-worthy.
+
+## 6. Phasing plan
+
+- **Phase 0** — live target + protocol spike. *(done implicitly while validating Phase 1)*
+- **Phase 1** — read-only MCP: observe + logs. ✅ **done, committed, validated live**
+- **Phase 2** — control the watch (rebuild / set-watch-state / abort). ✅ **done, validated live**
+- **Phase 3** — read-only rush commands (check/list/change/scan) via shell-out.
+- **Phase 4** — spawn-or-connect (stop requiring a pre-started watch).
+- **Phase 5** — mutating rush commands (the Path-1 stop-the-world dance).
+- **Phase 6** — multi-agent sharing + robustness (discovery file, race-safe spawn) → Path-2 decision.
+
+## 7. Implementation status
+
+Branch `nickpape/mcp-build-host-tools`. Phase 1 committed as `93ff2f453c`. Phase 2 implemented,
+compiles green, validated live — **not yet committed**.
+
+**Tools (all in `@rushstack/mcp-server`, sharing one lazy `RushServeClient`):**
+- `rush_build_status` — compact: host id, overall status, status counts, only non-green ops; `project`
+  filter + `includeAll`.
+- `rush_build_logs` — per-project/phase log, `tailLines` (default 200) + `errorsOnly`; disambiguates
+  multiple phases; "no errors" when stderr log absent.
+- `rush_rebuild` — invalidate a project's operations (force rebuild).
+- `rush_set_watch_state` — set enabled state (never|changed|affected|default) per project/phase.
+- `rush_abort_build` — abort the current execution pass.
+
+**File inventory:**
+- `apps/rush-mcp-server/src/buildHost/protocol.types.ts` — local mirror of rush-serve `/api` (events + commands).
+- `apps/rush-mcp-server/src/buildHost/RushServeClient.ts` — lazy wss client, in-memory snapshot,
+  `findOperations`, `sendCommandAsync`, https log fetch (`undefined` on 404). URL via
+  `RUSH_BUILD_STATUS_WS_URL` (default `wss://localhost:8443/`); TLS via `rejectUnauthorized:false`
+  (TODO: trust the debug CA).
+- `apps/rush-mcp-server/src/tools/build-status.tool.ts`, `build-logs.tool.ts`, `build-rebuild.tool.ts`,
+  `build-watch-state.tool.ts`, `build-abort.tool.ts`.
+- Wired in `src/server.ts` + `src/tools/index.ts`. Added deps `ws ~8.20.0` + `@types/ws 8.5.5`.
+
+## 8. Validation log & gotchas (chronological)
+
+- **Build:** fresh checkout → first build needs the toolchain via `rush build --to @rushstack/mcp-server`
+  (~2 min); thereafter `rush build --only @rushstack/mcp-server` (~11 s).
+- **Compile gotcha:** `ClientRequest` is exported from `node:http`, not `node:https`.
+- **Phase 1 live (against real `rush start` + rush-serve):** status (compact/includeAll/filter),
+  multi-phase log disambiguation, and HTTPS log tail all worked.
+- **Log gotcha (fixed):** `.error.log` only exists when there's stderr → `errorsOnly` 404'd on clean
+  builds. `fetchLogTextAsync` now returns `undefined` on 404; the logs tool reports "no errors."
+- **Lock observed live:** `rush build` refused while the watch held the lock ("Another Rush command is
+  already running"). Workaround for compiling during a watch: run the project's local
+  `apps/rush-mcp-server/node_modules/.bin/heft build` (bypasses the orchestrator lock).
+- **Phase 2 live:** `rush_rebuild` fired while the watch was idle produced
+  `Watch Status: Projects were invalidated: @rushstack/tree-pattern (build) (Invalidated via WebSocket)`
+  → fresh build cycle. set-watch-state and abort accepted.
+- **rush-serve behavior #1 (cold watch):** `invalidate` / `set-enabled-states` are **no-ops until the
+  first watch iteration runs**, because rush-serve captures `context.invalidateOperation` in its
+  createOperations tap and `PhasedScriptAction` only supplies it in the watch loop (~line 928), not the
+  initial build. Design implication: MCP may want to surface "watch not warmed yet" or nudge an initial
+  iteration so control tools work immediately.
+- **rush-serve behavior #2 (coalescing):** an `invalidate` sent while a build is in-flight folds into
+  the running build (no separate cycle).
+
+## 9. Running the live test harness (repro)
+
+Wired into THIS repo for validation (kept uncommitted — it's a harness, not the feature):
+1. `common/autoinstallers/plugins/package.json` ← add `@rushstack/rush-serve-plugin@5.175.1`.
+2. `common/config/rush/rush-plugins.json` ← register the plugin (autoinstaller `plugins`).
+3. `common/config/rush-plugins/rush-serve-plugin.json` ← `{ phasedCommands:["start"],
+   buildStatusWebSocketPath:"/", logServePath:"/log" }`.
+4. `rush update --bypass-policy` (full update harvests the plugin manifest — `update-autoinstaller`
+   alone gives "Manifest not found"; `--bypass-policy` skips this repo's git-email policy).
+5. `rush start --only @rushstack/tree-pattern` (small prebuilt project). It prints
+   `Content is being served from: https://localhost:<PORT>/`.
+6. Point the client at it: `RUSH_BUILD_STATUS_WS_URL=wss://localhost:<PORT>/` and call the built tools
+   in `apps/rush-mcp-server/lib-commonjs/...`.
+- Git identity isn't set in this repo; commit with inline
+  `-c user.email=nickpape@outlook.com -c user.name="Nick Pape"`. Pre-commit hook runs `rush prettier`.
+
+## 10. Open questions / next steps
+
+- Commit Phase 2 (feature files only)?
+- Phase 3: read-only `rush check`/`list` via the existing `CommandRunner` shell-out.
+- Cold-watch handling (behavior #1) — surface state or auto-warm?
+- Discovery / spawn-or-connect (Phase 4): rush-serve has no discovery file; likely add one
+  (port + wsPath + logServePath + repoId + pid), upstream-able.
+- TLS hardening: trust the debug CA instead of `rejectUnauthorized:false`.
+- Whether to commit the rush-serve test harness or document it as setup.


### PR DESCRIPTION
## Summary

Adds first-class tools to `@rushstack/mcp-server` that let an agent **observe and control a running Rush build/watch host without invoking `rush` directly** (avoids token waste, lockfile contention between parallel agents, and the need for shell access).

A persistent **build-host daemon** owns one shared `rush start` + `@rushstack/rush-serve-plugin` watch and advertises it via a discovery file; MCP clients discover/start it and connect to its WebSocket (status/control) and HTTPS log endpoint. Because the daemon owns the watch, it is shared across agents and survives individual MCP processes.

### Tools
- `rush_build_status` — compact status: host id, overall status, status counts, and only the failing/warning/in-progress operations (`project` filter + `includeAll`).
- `rush_build_logs` — per-project/phase log, tailed (`tailLines`) and optionally `errorsOnly`.
- `rush_rebuild` — invalidate a project's operations to force a rebuild.
- `rush_set_watch_state` — set enabled state (`never`/`changed`/`affected`/`default`) per project/phase.
- `rush_abort_build` — abort the current execution pass.
- `rush_run_command` — run an allowed Rush command. Read-only (`check`, `list`) run directly; **mutating** (`install`, `update`, `add`, `remove`) stop the shared daemon to free the repo lock, run, and the daemon restarts lazily. Allowlist enforced in both schema and handler.
- `rush_shutdown_host` — stop the shared daemon (restarts on next build query).

### Daemon / connection / lifecycle
The client connects lazily: configured `RUSHMCP_BUILD_STATUS_WS_URL` → discovery file (`common/temp/rushmcp-build-host.json`) → else start the daemon (detached, race-safe via a launch lock) and wait for it to serve. The daemon (singleton via a lock) supervises the watch, scrapes its ephemeral port, writes discovery, and reaps the watch tree via `SubprocessTerminator` on its own exit/signals. The client never owns the watch (`disposeAsync` is a no-op), so the host survives MCP exits and is shared.

> Config uses the `RUSHMCP_` prefix, not `RUSH_`: Rush rejects unrecognized `RUSH_`-prefixed env vars, which a spawned `rush` would inherit.

## Phases (18 commits)
1. **Observe + logs** · 2. **Control** · 3. **Read-only commands** · 4. **Spawn-or-connect** · 5. **Reaping hardening** (`SubprocessTerminator`) · 6. **Mutating commands** · 7. **Daemon (Path 2)**: foundation (supervisor + discovery), client wiring (discover/start/share + shutdown tool), and watch **supervision/auto-restart**.

Plus a `[repo]` commit enabling `rush-serve-plugin` for the `start` command (**local test harness**, may not belong upstream) and `[docs]` updates to `rush-ipc-mcp-findings.md` (design + validation log, incl. the §11 daemon design).

## Validation
Compiles green (TypeScript + lint). Exercised end-to-end against a real `rush start` + rush-serve (via a `rush` shim where `rush` isn't on PATH): status/logs incl. multi-phase + `errorsOnly`; `rush_rebuild` logged by Rush as `Invalidated via WebSocket`; `rush_run_command` running `list`/`check` and a mutating `install`; reliable reaping (no orphans, lock released); **daemon**: one client cold-started it and exited, the daemon persisted, a second client reused the same daemon (one process), mutating stopped+restarted it, and `rush_shutdown_host` stopped it cleanly.

## Notes / next
- Self-signed debug cert handled with `rejectUnauthorized:false` (TODO: trust the CA).
- rush-serve behaviors (findings doc): control commands are no-ops until the first watch iteration; an invalidate sent mid-build coalesces.
- Remaining (findings §11): daemon-*mediated* mutating commands were intentionally deferred (the current "stop the daemon, run, lazy restart" is correct and composes with supervision; proper mediation belongs in 6d). 6d = the upstream `rush daemon` in rush-lib that holds the lock once and runs install/update/check via the manager classes in-process (no child `rush start`) — a larger core change left for a dedicated PR.

Opened as an in-fork PR for diff review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
