### PR TITLE
rush-lib: in-process rush daemon (PhasedCommandRunner + control socket + in-process install)

### DIFF
--- a/RUSH-DAEMON-6D.md
+++ b/RUSH-DAEMON-6D.md
@@ -87,3 +87,34 @@ Validation gate (each step): rush-lib `heft test` 627/0 + local-rush regression
 (`rush build`, `rush start --watch`, and — for 6d-3 — `rush daemon` + socket: in-process install while
 watching, verify the watch resumes and the lock was never released). NOTE: `@microsoft/rush-lib` is
 published → a real PR needs a `rush change` entry.
+
+## 6d-2 / 6d-3 — DONE & validated (in-process commands under the held lock)
+
+Implemented as an experimental, env-gated (`RUSHMCP_DAEMON_SOCKET`) control channel on the watch
+(commits `f4f6fa69e4`, `355d47739d`) rather than a separate `rush daemon` action, to avoid the
+command-registration detour and reuse all existing `rush start` config. To be promoted to a first-class
+`RushDaemonAction` for upstream.
+
+- `DaemonControlServer` (unix socket, JSON-line protocol): `status`, `check` (read-only, no quiesce),
+  and `install` (mutating).
+- `PhasedCommandRunner.runExclusiveAsync(fn)`: pause the ProjectWatcher, abort + await the in-flight
+  build, run the `shutdownAsync` hook (stop IPC child procs), run `fn`, resume the watcher. Relies on
+  `waitForChangeAsync` parking while paused (verified in ProjectWatcher) so no build runs during `fn`.
+- `install` calls `doBasicInstallAsync` in-process via `runExclusiveAsync` — the watch process already
+  holds the `'rush'` lock, so it does NOT re-acquire it.
+
+**Validated (local rush, `rush start` + socket):** `status` → `{watching:true,pid}`; `check` ran
+in-process; `install` ran in-process WHILE watching (`ok=true`, "Install completed."), the daemon log
+showed `[PAUSED] → install → [WATCHING] resuming` with NO "Another Rush command is already running",
+and the watch then detected a new change and rebuilt. rush-lib `heft test` 627/0 throughout.
+
+**Finding:** `doBasicInstallAsync` runs the git-email policy internally (not just the action layer), so
+the first in-process install aborted until a git identity was set (`git config --local user.email ...`).
+Real users have this; the daemon may want to pass `bypassPolicy` or surface the policy error cleanly.
+
+## Remaining
+- update/add commands (update needs `allowShrinkwrapUpdates:true` — a different manager call than
+  `doBasicInstallAsync`); request queue so concurrent agents serialize.
+- Promote the env-gated prototype to a first-class `RushDaemonAction` (registration).
+- 6d-4: point the MCP `BuildHostDaemon` at this control socket (run mutating commands in-process via
+  the daemon instead of stop-daemon→install→restart).

--- a/RUSH-DAEMON-6D.md
+++ b/RUSH-DAEMON-6D.md
@@ -17,7 +17,15 @@ load `logic/installManager/doBasicInstallAsync` from the repo's published Rush. 
 install/update/check must be a same-bundle call inside rush-lib — exactly how `InstallAction` already
 calls `doBasicInstallAsync`.
 
-## 6d-1 — extract `PhasedCommandRunner` from `PhasedScriptAction`
+## 6d-1 — extract `PhasedCommandRunner` from `PhasedScriptAction` ✅ DONE (validated)
+
+Done in commit `4121bc9a96`. `PhasedScriptAction` 1196 → ~480 lines; engine moved to
+`PhasedCommandRunner.ts`. Validated: rush-lib `heft test` 627/0 (== baseline); local `rush build` and
+`rush start --watch` (initial build, watch loop, detected-change rebuild build+test) behave
+identically. NOTE for the eventual PR: `@microsoft/rush-lib` is published, so it needs a `rush change`
+changelog entry (skipped here — interactive).
+
+### Original plan (kept for reference)
 `PhasedScriptAction.ts` (1196 lines) → split into the **CLI action** (keeps the ~20 CommandLineParameter
 fields + `runAsync` parameter parsing, build-cache/cobuild config, project selection, plugin
 application, and the build of `ICreateOperationsContext`/`executionManagerOptions`) and a reusable

--- a/RUSH-DAEMON-6D.md
+++ b/RUSH-DAEMON-6D.md
@@ -54,3 +54,36 @@ behave identically (manual regression — the unit tests don't cover the watch p
 - 6d-3: control channel + in-process `install`/`update`/`check`/`add` via the managers, with
   `quiesce`/`resume` around them (no lock release). Validate the repeated-install-in-one-process risk.
 - 6d-4: point the MCP at `rush daemon`.
+
+## 6d-2 / 6d-3 — the daemon action + in-process commands (sharpened, code-grounded)
+
+Findings from tracing the wiring (so the next build is turnkey):
+- Phased commands are constructed in `cli/RushCommandLineParser.ts` (~line 489, `new PhasedScriptAction({...})`)
+  from `commandLineConfiguration` entries; built-ins (`build`/`rebuild`) come from `DEFAULT_BUILD_COMMAND_JSON`
+  in `api/CommandLineConfiguration.ts` (a bulk command translated to phased). A `daemon` built-in would be
+  added the same way — but a bare always-watch `daemon` command is just `rush start` and adds nothing.
+- The value is **in-process mutating commands under the one held lock**. `check` is read-only
+  (safe-for-simultaneous) so it doesn't exercise the lock benefit; the compelling demo is in-process
+  `install`/`update` *while watching*.
+
+Design:
+1. `RushDaemonAction extends PhasedScriptAction` (or PhasedScriptAction stores the runner on a
+   `protected` field). The action needs a handle to the live `PhasedCommandRunner` to control it.
+2. Add to `PhasedCommandRunner`: keep a reference to the active `ProjectWatcher`; add
+   `quiesceAsync()` (pause the watcher, abort the in-flight execution via `_executionAbortController`,
+   run the `shutdownAsync` hook to stop IPC workers) and `resumeAsync()` (resume the watcher). The
+   watch loop blocks in `projectWatcher.waitForChangeAsync()`, so quiesce must interrupt that wait;
+   `ProjectWatcher.pause()` already exists — confirm it unblocks the wait, else add an interrupt.
+3. A control channel (unix domain socket at `common/temp/rushmcp-daemon.sock`, JSON-line protocol:
+   `{command:'install'|'update'|'check'|'add'|'status', args}`). The daemon: on a mutating request →
+   `quiesceAsync()` → `doBasicInstallAsync` / `PackageJsonUpdater.doRushUpdateAsync` /
+   `VersionMismatchFinder.rushCheck` IN-PROCESS (no re-lock; the daemon already holds the 'rush' lock) →
+   `resumeAsync()` → reply with the result. Serialize requests (a queue) so concurrent agents don't
+   collide.
+4. Register the action (built-in default command or via command-line config).
+5. MCP (6d-4): point `BuildHostDaemon` at `rush daemon` and route mutating commands to the socket.
+
+Validation gate (each step): rush-lib `heft test` 627/0 + local-rush regression
+(`rush build`, `rush start --watch`, and — for 6d-3 — `rush daemon` + socket: in-process install while
+watching, verify the watch resumes and the lock was never released). NOTE: `@microsoft/rush-lib` is
+published → a real PR needs a `rush change` entry.

--- a/RUSH-DAEMON-6D.md
+++ b/RUSH-DAEMON-6D.md
@@ -1,0 +1,48 @@
+# 6d — in-process `rush daemon` (working branch)
+
+Branch: `nickpape/rush-daemon-phased-runner` (off `main`). Companion to the MCP build-host work on
+`nickpape/mcp-build-host-tools` (see that branch's `rush-ipc-mcp-findings.md` §11/§12 for the full
+design + why 6d must live in rush-lib).
+
+## Baseline (validated before any changes)
+- `rush build --only @microsoft/rush-lib` → green (cached).
+- `libraries/rush-lib` Jest suite (`heft test`) → **627 passed, 0 failed (~25s)**. This is the
+  refactor's safety net. NOTE: it barely covers the interactive watch loop — the real watch guardrail
+  is a manual `rush start` regression.
+
+## Why 6d lives in rush-lib (proven, not assumed)
+A spike confirmed there is **no external in-process path** to the install managers: rush-lib ships as a
+webpack bundle (internals aren't standalone-requirable), and rush-sdk/`RushInternals.loadModule` can't
+load `logic/installManager/doBasicInstallAsync` from the repo's published Rush. So in-process
+install/update/check must be a same-bundle call inside rush-lib — exactly how `InstallAction` already
+calls `doBasicInstallAsync`.
+
+## 6d-1 — extract `PhasedCommandRunner` from `PhasedScriptAction`
+`PhasedScriptAction.ts` (1196 lines) → split into the **CLI action** (keeps the ~20 CommandLineParameter
+fields + `runAsync` parameter parsing, build-cache/cobuild config, project selection, plugin
+application, and the build of `ICreateOperationsContext`/`executionManagerOptions`) and a reusable
+**`PhasedCommandRunner`** that owns the run engine.
+
+Methods to move into the runner (they call each other, so move as a unit):
+- `_runInitialPhasesAsync` (646) · `_runWatchPhasesAsync` (824) · `_registerWatchModeInterface` (725) ·
+  `_executeOperationsAsync` (970) · `_doBeforeTask` (1172) · `_doAfterTask` (1186).
+
+State the runner needs (constructor options): `hooks` (PhasedCommandHooks), `rushConfiguration`,
+`terminal`, `sessionAbortController`, `watchPhases`, `watchDebounceMs`, `ipcEnabled` (resolved from
+`--no-ipc`), and the initial `changedProjectsOnly`. Mutable run state moves into the runner:
+`_executionAbortController` (set in initial/watch runs; read by the 'a' abort key) and
+`_changedProjectsOnly` (toggled by the 'c' key; read when building the watch execute context).
+
+Public surface to expose for the daemon: `runInitialPhasesAsync()`, `runWatchLoopAsync()`, and
+`quiesceAsync()`/`resumeAsync()` (pause ProjectWatcher + cancel in-flight ops + run the `shutdownAsync`
+hook) **without releasing the 'rush' lock**. `PhasedScriptAction` becomes a thin wrapper that builds the
+runner and delegates; a new `rush daemon` action (6d-2) constructs the runner directly.
+
+Guardrail for the no-op refactor: `heft test` stays 627/0 AND `rush build` / `rush start --watch`
+behave identically (manual regression — the unit tests don't cover the watch path).
+
+## After 6d-1
+- 6d-2: add the `rush daemon` action (holds the lock, hosts the watch via the runner, rush-serve attached).
+- 6d-3: control channel + in-process `install`/`update`/`check`/`add` via the managers, with
+  `quiesce`/`resume` around them (no lock release). Validate the repeated-install-in-one-process risk.
+- 6d-4: point the MCP at `rush daemon`.

--- a/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
@@ -1,0 +1,138 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as net from 'node:net';
+
+import { FileSystem } from '@rushstack/node-core-library';
+import { type ITerminal, Terminal, StringBufferTerminalProvider } from '@rushstack/terminal';
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismatchFinder';
+
+/**
+ * A request received over the daemon control socket.
+ */
+interface IControlRequest {
+  id: number;
+  command: string;
+  args?: string[];
+}
+
+interface IControlResponse {
+  id: number;
+  ok: boolean;
+  text: string;
+}
+
+export interface IDaemonControlServerOptions {
+  socketPath: string;
+  rushConfiguration: RushConfiguration;
+  terminal: ITerminal;
+}
+
+/**
+ * EXPERIMENTAL (6d prototype): a control channel that lets a long-lived watch process additionally run
+ * Rush commands in-process, under the single repository lock the watch already holds. Read-only commands
+ * run directly; mutating commands run via `runExclusiveAsync`, which quiesces the watch first.
+ *
+ * This is gated behind the `RUSHMCP_DAEMON_SOCKET` environment variable and is the prototype seam for a
+ * future first-class `rush daemon` action.
+ */
+export class DaemonControlServer {
+  private readonly _options: IDaemonControlServerOptions;
+  private _server: net.Server | undefined;
+
+  public constructor(options: IDaemonControlServerOptions) {
+    this._options = options;
+  }
+
+  public start(): void {
+    const { socketPath, terminal } = this._options;
+    // Remove a stale socket file from a previous run.
+    FileSystem.deleteFile(socketPath);
+
+    const server: net.Server = net.createServer((socket: net.Socket) => {
+      let buffer: string = '';
+      socket.setEncoding('utf8');
+      socket.on('data', (chunk: string) => {
+        buffer += chunk;
+        let newlineIndex: number = buffer.indexOf('\n');
+        while (newlineIndex >= 0) {
+          const line: string = buffer.slice(0, newlineIndex);
+          buffer = buffer.slice(newlineIndex + 1);
+          if (line.trim()) {
+            void this._handleLineAsync(line, socket);
+          }
+          newlineIndex = buffer.indexOf('\n');
+        }
+      });
+      socket.on('error', () => {
+        /* client disconnected; ignore */
+      });
+    });
+
+    server.on('error', (error: Error) => {
+      terminal.writeErrorLine(`Daemon control server error: ${error.message}`);
+    });
+
+    server.listen(socketPath, () => {
+      terminal.writeLine(`Daemon control socket listening at ${socketPath}`);
+    });
+
+    this._server = server;
+  }
+
+  public close(): void {
+    if (this._server) {
+      this._server.close();
+      this._server = undefined;
+    }
+    FileSystem.deleteFile(this._options.socketPath);
+  }
+
+  private async _handleLineAsync(line: string, socket: net.Socket): Promise<void> {
+    let request: IControlRequest;
+    try {
+      request = JSON.parse(line);
+    } catch {
+      this._reply(socket, { id: 0, ok: false, text: 'Malformed request (expected JSON).' });
+      return;
+    }
+
+    try {
+      const text: string = await this._runCommandAsync(request.command, request.args ?? []);
+      this._reply(socket, { id: request.id, ok: true, text });
+    } catch (error) {
+      this._reply(socket, {
+        id: request.id,
+        ok: false,
+        text: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  private async _runCommandAsync(command: string, args: string[]): Promise<string> {
+    const { rushConfiguration } = this._options;
+    switch (command) {
+      case 'status': {
+        return JSON.stringify({ watching: true, pid: process.pid });
+      }
+      case 'check': {
+        // Read-only; safe to run alongside the watch without quiescing.
+        const provider: StringBufferTerminalProvider = new StringBufferTerminalProvider(false);
+        const terminal: Terminal = new Terminal(provider);
+        VersionMismatchFinder.rushCheck(rushConfiguration, terminal);
+        return provider.getOutput() + provider.getErrorOutput();
+      }
+      default: {
+        throw new Error(`Unknown or unsupported command: "${command}"`);
+      }
+    }
+  }
+
+  private _reply(socket: net.Socket, response: IControlResponse): void {
+    if (socket.writable) {
+      socket.write(JSON.stringify(response) + '\n');
+    }
+  }
+}

--- a/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
@@ -7,6 +7,7 @@ import { FileSystem } from '@rushstack/node-core-library';
 import { type ITerminal, Terminal, StringBufferTerminalProvider } from '@rushstack/terminal';
 
 import type { RushConfiguration } from '../../api/RushConfiguration';
+import type { RushGlobalFolder } from '../../api/RushGlobalFolder';
 import { VersionMismatchFinder } from '../../logic/versionMismatch/VersionMismatchFinder';
 
 /**
@@ -27,7 +28,13 @@ interface IControlResponse {
 export interface IDaemonControlServerOptions {
   socketPath: string;
   rushConfiguration: RushConfiguration;
+  rushGlobalFolder: RushGlobalFolder;
   terminal: ITerminal;
+  /**
+   * Runs `fn` with the watch quiesced (paused, in-flight execution aborted, child processes stopped)
+   * and the repository lock still held, then resumes the watch. Used for mutating commands.
+   */
+  runExclusiveAsync: (fn: () => Promise<void>) => Promise<void>;
 }
 
 /**
@@ -123,6 +130,23 @@ export class DaemonControlServer {
         const terminal: Terminal = new Terminal(provider);
         VersionMismatchFinder.rushCheck(rushConfiguration, terminal);
         return provider.getOutput() + provider.getErrorOutput();
+      }
+      case 'install': {
+        // Mutating: rewrite node_modules under the held lock, with the watch quiesced.
+        const provider: StringBufferTerminalProvider = new StringBufferTerminalProvider(false);
+        const terminal: Terminal = new Terminal(provider);
+        await this._options.runExclusiveAsync(async () => {
+          const { doBasicInstallAsync } = await import('../../logic/installManager/doBasicInstallAsync');
+          await doBasicInstallAsync({
+            rushConfiguration,
+            rushGlobalFolder: this._options.rushGlobalFolder,
+            isDebug: false,
+            variant: undefined,
+            terminal,
+            subspace: rushConfiguration.defaultSubspace
+          });
+        });
+        return provider.getOutput() + provider.getErrorOutput() || 'Install completed.';
       }
       default: {
         throw new Error(`Unknown or unsupported command: "${command}"`);

--- a/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/DaemonControlServer.ts
@@ -48,6 +48,8 @@ export interface IDaemonControlServerOptions {
 export class DaemonControlServer {
   private readonly _options: IDaemonControlServerOptions;
   private _server: net.Server | undefined;
+  // Serializes command execution so concurrent agents never run overlapping (e.g. mutating) commands.
+  private _commandQueue: Promise<void> = Promise.resolve();
 
   public constructor(options: IDaemonControlServerOptions) {
     this._options = options;
@@ -106,8 +108,17 @@ export class DaemonControlServer {
       return;
     }
 
+    // Queue the command so commands run one at a time, in arrival order.
+    const commandPromise: Promise<string> = this._commandQueue.then(() =>
+      this._runCommandAsync(request.command, request.args ?? [])
+    );
+    this._commandQueue = commandPromise.then(
+      () => undefined,
+      () => undefined
+    );
+
     try {
-      const text: string = await this._runCommandAsync(request.command, request.args ?? []);
+      const text: string = await commandPromise;
       this._reply(socket, { id: request.id, ok: true, text });
     } catch (error) {
       this._reply(socket, {

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedCommandRunner.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedCommandRunner.ts
@@ -1,0 +1,717 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { AlreadyReportedError } from '@rushstack/node-core-library';
+import { type ITerminal, Colorize } from '@rushstack/terminal';
+
+import type { RushConfiguration } from '../../api/RushConfiguration';
+import type {
+  PhasedCommandHooks,
+  ICreateOperationsContext,
+  IExecuteOperationsContext
+} from '../../pluginFramework/PhasedCommandHooks';
+import { Stopwatch, StopwatchState } from '../../utilities/Stopwatch';
+import {
+  type IOperationExecutionManagerOptions,
+  OperationExecutionManager
+} from '../../logic/operations/OperationExecutionManager';
+import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
+import type { IPhase } from '../../api/CommandLineConfiguration';
+import type { Operation } from '../../logic/operations/Operation';
+import type { OperationExecutionRecord } from '../../logic/operations/OperationExecutionRecord';
+import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
+import { OperationStatus } from '../../logic/operations/OperationStatus';
+import type {
+  IExecutionResult,
+  IOperationExecutionResult
+} from '../../logic/operations/IOperationExecutionResult';
+import type { ITelemetryData, ITelemetryOperationResult } from '../../logic/Telemetry';
+import type { IInputsSnapshot, GetInputsSnapshotAsyncFn } from '../../logic/incremental/InputsSnapshot';
+import type { ProjectWatcher } from '../../logic/ProjectWatcher';
+import { Selection } from '../../logic/Selection';
+import { measureAsyncFn, measureFn } from '../../utilities/performance';
+
+const PERF_PREFIX: 'rush:phasedScriptAction' = 'rush:phasedScriptAction';
+
+export interface IInitialRunPhasesOptions {
+  executionManagerOptions: Omit<
+    IOperationExecutionManagerOptions,
+    'beforeExecuteOperations' | 'inputsSnapshot'
+  >;
+  initialCreateOperationsContext: ICreateOperationsContext;
+  stopwatch: Stopwatch;
+  terminal: ITerminal;
+}
+
+export interface IRunPhasesOptions extends IInitialRunPhasesOptions {
+  getInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined;
+  initialSnapshot: IInputsSnapshot | undefined;
+  executionManagerOptions: IOperationExecutionManagerOptions;
+}
+
+interface IExecuteOperationsOptions {
+  executeOperationsContext: IExecuteOperationsContext;
+  executionManagerOptions: IOperationExecutionManagerOptions;
+  ignoreHooks: boolean;
+  operations: Set<Operation>;
+  stopwatch: Stopwatch;
+  terminal: ITerminal;
+}
+
+interface IPhasedCommandTelemetry {
+  [key: string]: string | number | boolean;
+  isInitial: boolean;
+  isWatch: boolean;
+
+  countAll: number;
+  countSuccess: number;
+  countSuccessWithWarnings: number;
+  countFailure: number;
+  countBlocked: number;
+  countFromCache: number;
+  countSkipped: number;
+  countNoOp: number;
+}
+
+/**
+ * Options for the {@link PhasedCommandRunner}. The CLI action resolves all of these from its parsed
+ * parameters and injects the CLI-specific glue (telemetry logging, telemetry extra-data, and the
+ * post-task event-hook handler) as callbacks, so the runner itself is reusable outside the one-shot
+ * CLI invocation lifecycle (e.g. by a long-lived `rush daemon`).
+ */
+export interface IPhasedCommandRunnerOptions {
+  actionName: string;
+  hooks: PhasedCommandHooks;
+  rushConfiguration: RushConfiguration;
+  terminal: ITerminal;
+  isDebug: boolean;
+  sessionAbortController: AbortController;
+  watchPhases: ReadonlySet<IPhase>;
+  watchDebounceMs: number;
+  /** Whether the IPC feature is enabled (i.e. `--no-ipc` was not passed). */
+  ipcEnabled: boolean;
+  /** The initial value of changed-projects-only mode (toggleable at runtime in watch mode). */
+  changedProjectsOnly: boolean;
+  /**
+   * The name under which to report changed-projects-only mode in telemetry, or `undefined` if the
+   * parameter is not defined for this command.
+   */
+  changedProjectsOnlyParameterName: string | undefined;
+  /** Returns the base extra-data map for telemetry (selection + parameter values). */
+  getTelemetryExtraData: () => Record<string, string | number | boolean>;
+  /** Logs (and flushes) a telemetry entry, or `undefined` if telemetry is disabled. */
+  logTelemetry: ((entry: ITelemetryData) => void) | undefined;
+  /** Invoked after an execution pass completes (unless hooks are ignored), e.g. to run event hooks. */
+  onAfterExecuteTask: () => void;
+}
+
+/**
+ * Runs the operation graph for a phased command: the initial execution pass and, optionally, the
+ * watch-mode loop. Extracted from `PhasedScriptAction` so that the same engine can be hosted by a
+ * long-lived process (the `rush daemon`) in addition to a one-shot CLI invocation.
+ */
+export class PhasedCommandRunner {
+  private readonly _actionName: string;
+  private readonly _hooks: PhasedCommandHooks;
+  private readonly _rushConfiguration: RushConfiguration;
+  private readonly _terminal: ITerminal;
+  private readonly _isDebug: boolean;
+  private readonly _sessionAbortController: AbortController;
+  private readonly _watchPhases: ReadonlySet<IPhase>;
+  private readonly _watchDebounceMs: number;
+  private readonly _ipcEnabled: boolean;
+  private readonly _changedProjectsOnlyParameterName: string | undefined;
+  private readonly _getTelemetryExtraData: () => Record<string, string | number | boolean>;
+  private readonly _logTelemetry: ((entry: ITelemetryData) => void) | undefined;
+  private readonly _onAfterExecuteTask: () => void;
+
+  private _changedProjectsOnly: boolean;
+  private _executionAbortController: AbortController | undefined;
+  private _activeProjectWatcher: ProjectWatcher | undefined;
+  private _executingPromise: Promise<void> | undefined;
+
+  public constructor(options: IPhasedCommandRunnerOptions) {
+    this._actionName = options.actionName;
+    this._hooks = options.hooks;
+    this._rushConfiguration = options.rushConfiguration;
+    this._terminal = options.terminal;
+    this._isDebug = options.isDebug;
+    this._sessionAbortController = options.sessionAbortController;
+    this._watchPhases = options.watchPhases;
+    this._watchDebounceMs = options.watchDebounceMs;
+    this._ipcEnabled = options.ipcEnabled;
+    this._changedProjectsOnlyParameterName = options.changedProjectsOnlyParameterName;
+    this._getTelemetryExtraData = options.getTelemetryExtraData;
+    this._logTelemetry = options.logTelemetry;
+    this._onAfterExecuteTask = options.onAfterExecuteTask;
+
+    this._changedProjectsOnly = options.changedProjectsOnly;
+    this._executionAbortController = undefined;
+    this._activeProjectWatcher = undefined;
+    this._executingPromise = undefined;
+
+    this._sessionAbortController.signal.addEventListener(
+      'abort',
+      () => {
+        this._executionAbortController?.abort();
+      },
+      { once: true }
+    );
+  }
+
+  public async runInitialPhasesAsync(options: IInitialRunPhasesOptions): Promise<IRunPhasesOptions> {
+    const {
+      initialCreateOperationsContext,
+      executionManagerOptions: partialExecutionManagerOptions,
+      stopwatch,
+      terminal
+    } = options;
+
+    const { projectConfigurations } = initialCreateOperationsContext;
+    const { projectSelection } = initialCreateOperationsContext;
+
+    const operations: Set<Operation> = await measureAsyncFn(`${PERF_PREFIX}:createOperations`, () =>
+      this._hooks.createOperations.promise(new Set(), initialCreateOperationsContext)
+    );
+
+    const [getInputsSnapshotAsync, initialSnapshot] = await measureAsyncFn(
+      `${PERF_PREFIX}:analyzeRepoState`,
+      async () => {
+        terminal.write('Analyzing repo state... ');
+        const repoStateStopwatch: Stopwatch = new Stopwatch();
+        repoStateStopwatch.start();
+
+        const analyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this._rushConfiguration);
+        const innerGetInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined =
+          await analyzer._tryGetSnapshotProviderAsync(
+            projectConfigurations,
+            terminal,
+            // We need to include all dependencies, otherwise build cache id calculation will be incorrect
+            Selection.expandAllDependencies(projectSelection)
+          );
+        const innerInitialSnapshot: IInputsSnapshot | undefined = innerGetInputsSnapshotAsync
+          ? await innerGetInputsSnapshotAsync()
+          : undefined;
+
+        repoStateStopwatch.stop();
+        terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
+        terminal.writeLine();
+        return [innerGetInputsSnapshotAsync, innerInitialSnapshot];
+      }
+    );
+
+    const abortController: AbortController = (this._executionAbortController = new AbortController());
+    const initialExecuteOperationsContext: IExecuteOperationsContext = {
+      ...initialCreateOperationsContext,
+      inputsSnapshot: initialSnapshot,
+      abortController
+    };
+
+    const executionManagerOptions: IOperationExecutionManagerOptions = {
+      ...partialExecutionManagerOptions,
+      inputsSnapshot: initialSnapshot,
+      beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
+        await measureAsyncFn(`${PERF_PREFIX}:beforeExecuteOperations`, () =>
+          this._hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext)
+        );
+      }
+    };
+
+    const initialOptions: IExecuteOperationsOptions = {
+      executeOperationsContext: initialExecuteOperationsContext,
+      ignoreHooks: false,
+      operations,
+      stopwatch,
+      executionManagerOptions,
+      terminal
+    };
+
+    await measureAsyncFn(`${PERF_PREFIX}:executeOperations`, () =>
+      this._executeOperationsAsync(initialOptions)
+    );
+
+    return {
+      ...options,
+      executionManagerOptions,
+      getInputsSnapshotAsync,
+      initialSnapshot
+    };
+  }
+
+  private _registerWatchModeInterface(projectWatcher: ProjectWatcher): void {
+    const buildOnceKey: 'b' = 'b';
+    const changedProjectsOnlyKey: 'c' = 'c';
+    const invalidateKey: 'i' = 'i';
+    const quitKey: 'q' = 'q';
+    const abortKey: 'a' = 'a';
+    const toggleWatcherKey: 'w' = 'w';
+    const shutdownProcessesKey: 'x' = 'x';
+
+    const terminal: ITerminal = this._terminal;
+
+    projectWatcher.setPromptGenerator((isPaused: boolean) => {
+      const promptLines: string[] = [
+        `  Press <${quitKey}> to gracefully exit.`,
+        `  Press <${abortKey}> to abort queued operations. Any that have started will finish.`,
+        `  Press <${toggleWatcherKey}> to ${isPaused ? 'resume' : 'pause'}.`,
+        `  Press <${invalidateKey}> to invalidate all projects.`,
+        `  Press <${changedProjectsOnlyKey}> to ${
+          this._changedProjectsOnly ? 'disable' : 'enable'
+        } changed-projects-only mode (${this._changedProjectsOnly ? 'ENABLED' : 'DISABLED'}).`
+      ];
+      if (isPaused) {
+        promptLines.push(`  Press <${buildOnceKey}> to build once.`);
+      }
+      if (this._ipcEnabled) {
+        promptLines.push(`  Press <${shutdownProcessesKey}> to reset child processes.`);
+      }
+      return promptLines;
+    });
+
+    const onKeyPress = (key: string): void => {
+      switch (key) {
+        case quitKey:
+          terminal.writeLine(`Exiting watch mode and aborting any scheduled work...`);
+          process.stdin.setRawMode(false);
+          process.stdin.off('data', onKeyPress);
+          process.stdin.unref();
+          this._sessionAbortController.abort();
+          break;
+        case abortKey:
+          terminal.writeLine(`Aborting current iteration...`);
+          this._executionAbortController?.abort();
+          break;
+        case toggleWatcherKey:
+          if (projectWatcher.isPaused) {
+            projectWatcher.resume();
+          } else {
+            projectWatcher.pause();
+          }
+          break;
+        case buildOnceKey:
+          if (projectWatcher.isPaused) {
+            projectWatcher.clearStatus();
+            terminal.writeLine(`Building once...`);
+            projectWatcher.resume();
+            projectWatcher.pause();
+          }
+          break;
+        case invalidateKey:
+          projectWatcher.clearStatus();
+          terminal.writeLine(`Invalidating all operations...`);
+          projectWatcher.invalidateAll('manual trigger');
+          if (!projectWatcher.isPaused) {
+            projectWatcher.resume();
+          }
+          break;
+        case changedProjectsOnlyKey:
+          this._changedProjectsOnly = !this._changedProjectsOnly;
+          projectWatcher.rerenderStatus();
+          break;
+        case shutdownProcessesKey:
+          projectWatcher.clearStatus();
+          terminal.writeLine(`Shutting down long-lived child processes...`);
+          // TODO: Inject this promise into the execution queue somewhere so that it gets waited on between runs
+          void this._hooks.shutdownAsync.promise();
+          break;
+        case '':
+          process.stdin.setRawMode(false);
+          process.stdin.off('data', onKeyPress);
+          process.stdin.unref();
+          this._sessionAbortController.abort();
+          process.kill(process.pid, 'SIGINT');
+          break;
+      }
+    };
+
+    process.stdin.setRawMode(true);
+    process.stdin.resume();
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', onKeyPress);
+  }
+
+  /**
+   * Runs the command in watch mode. Fundamentally is a simple loop:
+   * 1) Wait for a change to one or more projects in the selection
+   * 2) Invoke the command on the changed projects, and, if applicable, impacted projects
+   *    Uses the same algorithm as --impacted-by
+   * 3) Goto (1)
+   */
+  public async runWatchPhasesAsync(options: IRunPhasesOptions): Promise<void> {
+    const {
+      getInputsSnapshotAsync,
+      initialSnapshot,
+      initialCreateOperationsContext,
+      executionManagerOptions,
+      stopwatch,
+      terminal
+    } = options;
+
+    const phaseOriginal: Set<IPhase> = new Set(this._watchPhases);
+    const phaseSelection: Set<IPhase> = new Set(this._watchPhases);
+
+    const { projectSelection: projectsToWatch } = initialCreateOperationsContext;
+
+    if (!getInputsSnapshotAsync || !initialSnapshot) {
+      terminal.writeErrorLine(
+        `Cannot watch for changes if the Rush repo is not in a Git repository, exiting.`
+      );
+      throw new AlreadyReportedError();
+    }
+
+    // Use async import so that we don't pay the cost for sync builds
+    const { ProjectWatcher } = await import(
+      /* webpackChunkName: 'ProjectWatcher' */
+      '../../logic/ProjectWatcher'
+    );
+
+    const sessionAbortController: AbortController = this._sessionAbortController;
+    const abortSignal: AbortSignal = sessionAbortController.signal;
+
+    const projectWatcher: typeof ProjectWatcher.prototype = new ProjectWatcher({
+      getInputsSnapshotAsync,
+      initialSnapshot,
+      debounceMs: this._watchDebounceMs,
+      rushConfiguration: this._rushConfiguration,
+      projectsToWatch,
+      abortSignal,
+      terminal
+    });
+    this._activeProjectWatcher = projectWatcher;
+
+    // Ensure process.stdin allows interactivity before using TTY-only APIs
+    if (process.stdin.isTTY) {
+      this._registerWatchModeInterface(projectWatcher);
+    }
+
+    const onWaitingForChanges = (): void => {
+      // Allow plugins to display their own messages when waiting for changes.
+      this._hooks.waitingForChanges.call();
+
+      // Report so that the developer can always see that it is in watch mode as the latest console line.
+      terminal.writeLine(
+        `Watching for changes to ${projectsToWatch.size} ${
+          projectsToWatch.size === 1 ? 'project' : 'projects'
+        }. Press Ctrl+C to exit.`
+      );
+    };
+
+    function invalidateOperation(operation: Operation, reason: string): void {
+      const { associatedProject } = operation;
+      // Since ProjectWatcher only tracks entire projects, widen the operation to its project
+      // Revisit when migrating to @rushstack/operation-graph and we have a long-lived operation graph
+      projectWatcher.invalidateProject(associatedProject, `${operation.name!} (${reason})`);
+    }
+
+    // Loop until Ctrl+C
+    while (!abortSignal.aborted) {
+      // On the initial invocation, this promise will return immediately with the full set of projects
+      const { changedProjects, inputsSnapshot: state } = await measureAsyncFn(
+        `${PERF_PREFIX}:waitForChanges`,
+        () => projectWatcher.waitForChangeAsync(onWaitingForChanges)
+      );
+
+      if (abortSignal.aborted) {
+        return;
+      }
+
+      if (stopwatch.state === StopwatchState.Stopped) {
+        // Clear and reset the stopwatch so that we only report time from a single execution at a time
+        stopwatch.reset();
+        stopwatch.start();
+      }
+
+      terminal.writeLine(
+        `Detected changes in ${changedProjects.size} project${changedProjects.size === 1 ? '' : 's'}:`
+      );
+      const names: string[] = [...changedProjects].map((x: RushConfigurationProject) => x.packageName).sort();
+      for (const name of names) {
+        terminal.writeLine(`    ${Colorize.cyan(name)}`);
+      }
+
+      const initialAbortController: AbortController = (this._executionAbortController =
+        new AbortController());
+
+      // Account for consumer relationships
+      const executeOperationsContext: IExecuteOperationsContext = {
+        ...initialCreateOperationsContext,
+        abortController: initialAbortController,
+        changedProjectsOnly: !!this._changedProjectsOnly,
+        isInitial: false,
+        inputsSnapshot: state,
+        projectsInUnknownState: changedProjects,
+        phaseOriginal,
+        phaseSelection,
+        invalidateOperation
+      };
+
+      const operations: Set<Operation> = await measureAsyncFn(`${PERF_PREFIX}:createOperations`, () =>
+        this._hooks.createOperations.promise(new Set(), executeOperationsContext)
+      );
+
+      const executeOptions: IExecuteOperationsOptions = {
+        executeOperationsContext,
+        // For now, don't run pre-build or post-build in watch mode
+        ignoreHooks: true,
+        operations,
+        stopwatch,
+        executionManagerOptions: {
+          ...executionManagerOptions,
+          inputsSnapshot: state,
+          beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
+            await measureAsyncFn(`${PERF_PREFIX}:beforeExecuteOperations`, () =>
+              this._hooks.beforeExecuteOperations.promise(records, executeOperationsContext)
+            );
+          }
+        },
+        terminal
+      };
+
+      const iterationPromise: Promise<void> = measureAsyncFn(`${PERF_PREFIX}:executeOperations`, () =>
+        this._executeOperationsAsync(executeOptions)
+      );
+      this._executingPromise = iterationPromise;
+      try {
+        // Delegate to the underlying command, for only the projects that need reprocessing
+        await iterationPromise;
+      } catch (err) {
+        // In watch mode, we want to rebuild even if the original build failed.
+        if (!(err instanceof AlreadyReportedError)) {
+          throw err;
+        }
+      } finally {
+        this._executingPromise = undefined;
+      }
+    }
+
+    this._activeProjectWatcher = undefined;
+  }
+
+  /**
+   * Runs `fn` exclusively against the watch: pauses the watcher, aborts and awaits any in-flight
+   * execution, stops long-lived child build processes (the `shutdownAsync` hook), runs `fn` (e.g. an
+   * in-process install) while the repository lock is still held, then resumes the watch. Safe to call
+   * when no watch is active (`fn` simply runs).
+   */
+  public async runExclusiveAsync(fn: () => Promise<void>): Promise<void> {
+    const watcher: ProjectWatcher | undefined = this._activeProjectWatcher;
+    watcher?.pause();
+    // Stop any in-flight build before mutating node_modules, and wait for it to fully unwind.
+    this._executionAbortController?.abort();
+    if (this._executingPromise) {
+      try {
+        await this._executingPromise;
+      } catch {
+        // The in-flight execution was aborted; ignore.
+      }
+    }
+    // Child build processes may hold stale module resolutions once node_modules changes.
+    await this._hooks.shutdownAsync.promise();
+    try {
+      await fn();
+    } finally {
+      watcher?.resume();
+    }
+  }
+
+  /**
+   * Runs a set of operations and reports the results.
+   */
+  private async _executeOperationsAsync(options: IExecuteOperationsOptions): Promise<void> {
+    const {
+      executeOperationsContext,
+      executionManagerOptions,
+      ignoreHooks,
+      operations,
+      stopwatch,
+      terminal
+    } = options;
+
+    const executionManager: OperationExecutionManager = new OperationExecutionManager(
+      operations,
+      executionManagerOptions
+    );
+
+    const { isInitial, isWatch, abortController, invalidateOperation } = executeOperationsContext;
+
+    let success: boolean = false;
+    let result: IExecutionResult | undefined;
+
+    try {
+      const definiteResult: IExecutionResult = await measureAsyncFn(
+        `${PERF_PREFIX}:executeOperationsInner`,
+        () => executionManager.executeAsync(abortController)
+      );
+      success = definiteResult.status === OperationStatus.Success;
+      result = definiteResult;
+
+      await measureAsyncFn(`${PERF_PREFIX}:afterExecuteOperations`, () =>
+        this._hooks.afterExecuteOperations.promise(definiteResult, executeOperationsContext)
+      );
+
+      stopwatch.stop();
+
+      const message: string = `rush ${this._actionName} (${stopwatch.toString()})`;
+      if (result.status === OperationStatus.Success) {
+        terminal.writeLine(Colorize.green(message));
+      } else {
+        terminal.writeLine(message);
+      }
+    } catch (error) {
+      success = false;
+      stopwatch.stop();
+
+      if (error instanceof AlreadyReportedError) {
+        terminal.writeLine(`rush ${this._actionName} (${stopwatch.toString()})`);
+      } else {
+        if (error && (error as Error).message) {
+          if (this._isDebug) {
+            terminal.writeErrorLine('Error: ' + (error as Error).stack);
+          } else {
+            terminal.writeErrorLine('Error: ' + (error as Error).message);
+          }
+        }
+
+        terminal.writeErrorLine(Colorize.red(`rush ${this._actionName} - Errors! (${stopwatch.toString()})`));
+      }
+    }
+
+    this._executionAbortController = undefined;
+
+    if (invalidateOperation) {
+      const operationResults: ReadonlyMap<Operation, IOperationExecutionResult> | undefined =
+        result?.operationResults;
+      if (operationResults) {
+        for (const [operation, { status }] of operationResults) {
+          if (status === OperationStatus.Aborted) {
+            invalidateOperation(operation, 'aborted');
+          }
+        }
+      }
+    }
+
+    if (!ignoreHooks) {
+      measureFn(`${PERF_PREFIX}:doAfterTask`, () => this._onAfterExecuteTask());
+    }
+
+    if (this._logTelemetry) {
+      const logTelemetry: (entry: ITelemetryData) => void = this._logTelemetry;
+      const logEntry: ITelemetryData = measureFn(`${PERF_PREFIX}:prepareTelemetry`, () => {
+        const jsonOperationResults: Record<string, ITelemetryOperationResult> = {};
+
+        const extraData: IPhasedCommandTelemetry = {
+          // Fields preserved across the command invocation
+          ...this._getTelemetryExtraData(),
+          isWatch,
+          // Fields specific to the current operation set
+          isInitial,
+
+          countAll: 0,
+          countSuccess: 0,
+          countSuccessWithWarnings: 0,
+          countFailure: 0,
+          countBlocked: 0,
+          countFromCache: 0,
+          countSkipped: 0,
+          countNoOp: 0
+        };
+
+        if (this._changedProjectsOnlyParameterName) {
+          // Overwrite this value since we allow changing it at runtime.
+          extraData[this._changedProjectsOnlyParameterName] = this._changedProjectsOnly;
+        }
+
+        if (result) {
+          const { operationResults } = result;
+
+          const nonSilentDependenciesByOperation: Map<Operation, Set<string>> = new Map();
+          function getNonSilentDependencies(operation: Operation): ReadonlySet<string> {
+            let realDependencies: Set<string> | undefined = nonSilentDependenciesByOperation.get(operation);
+            if (!realDependencies) {
+              realDependencies = new Set();
+              nonSilentDependenciesByOperation.set(operation, realDependencies);
+              for (const dependency of operation.dependencies) {
+                const dependencyRecord: IOperationExecutionResult | undefined =
+                  operationResults.get(dependency);
+                if (dependencyRecord?.silent) {
+                  for (const deepDependency of getNonSilentDependencies(dependency)) {
+                    realDependencies.add(deepDependency);
+                  }
+                } else {
+                  realDependencies.add(dependency.name!);
+                }
+              }
+            }
+            return realDependencies;
+          }
+
+          for (const [operation, operationResult] of operationResults) {
+            if (operationResult.silent) {
+              // Architectural operation. Ignore.
+              continue;
+            }
+
+            const { _operationMetadataManager: operationMetadataManager } =
+              operationResult as OperationExecutionRecord;
+
+            const { startTime, endTime } = operationResult.stopwatch;
+            jsonOperationResults[operation.name!] = {
+              startTimestampMs: startTime,
+              endTimestampMs: endTime,
+              nonCachedDurationMs: operationResult.nonCachedDurationMs,
+              wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt !== true,
+              result: operationResult.status,
+              dependencies: Array.from(getNonSilentDependencies(operation)).sort()
+            };
+
+            extraData.countAll++;
+            switch (operationResult.status) {
+              case OperationStatus.Success:
+                extraData.countSuccess++;
+                break;
+              case OperationStatus.SuccessWithWarning:
+                extraData.countSuccessWithWarnings++;
+                break;
+              case OperationStatus.Failure:
+                extraData.countFailure++;
+                break;
+              case OperationStatus.Blocked:
+                extraData.countBlocked++;
+                break;
+              case OperationStatus.FromCache:
+                extraData.countFromCache++;
+                break;
+              case OperationStatus.Skipped:
+                extraData.countSkipped++;
+                break;
+              case OperationStatus.NoOp:
+                extraData.countNoOp++;
+                break;
+              default:
+                // Do nothing.
+                break;
+            }
+          }
+        }
+
+        const innerLogEntry: ITelemetryData = {
+          name: this._actionName,
+          durationInSeconds: stopwatch.duration,
+          result: success ? 'Succeeded' : 'Failed',
+          extraData,
+          operationResults: jsonOperationResults
+        };
+
+        return innerLogEntry;
+      });
+
+      measureFn(`${PERF_PREFIX}:beforeLog`, () => this._hooks.beforeLog.call(logEntry));
+
+      logTelemetry(logEntry);
+    }
+
+    if (!success && !isWatch) {
+      throw new AlreadyReportedError();
+    }
+  }
+}

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -611,7 +611,9 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           daemonControlServer = new DaemonControlServer({
             socketPath: daemonSocketPath,
             rushConfiguration: this.rushConfiguration,
-            terminal
+            rushGlobalFolder: this.rushGlobalFolder,
+            terminal,
+            runExclusiveAsync: (fn: () => Promise<void>) => runner.runExclusiveAsync(fn)
           });
           daemonControlServer.start();
         }

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -3,7 +3,6 @@
 
 import type { AsyncSeriesHook } from 'tapable';
 
-import { AlreadyReportedError } from '@rushstack/node-core-library';
 import { type ITerminal, Terminal, Colorize } from '@rushstack/terminal';
 import type {
   CommandLineFlagParameter,
@@ -13,47 +12,36 @@ import type {
 
 import type { Subspace } from '../../api/Subspace';
 import type { IPhasedCommand } from '../../pluginFramework/RushLifeCycle';
-import {
-  PhasedCommandHooks,
-  type ICreateOperationsContext,
-  type IExecuteOperationsContext
-} from '../../pluginFramework/PhasedCommandHooks';
+import { PhasedCommandHooks, type ICreateOperationsContext } from '../../pluginFramework/PhasedCommandHooks';
 import { SetupChecks } from '../../logic/SetupChecks';
-import { Stopwatch, StopwatchState } from '../../utilities/Stopwatch';
+import { Stopwatch } from '../../utilities/Stopwatch';
 import { BaseScriptAction, type IBaseScriptActionOptions } from './BaseScriptAction';
 import {
-  type IOperationExecutionManagerOptions,
-  OperationExecutionManager
-} from '../../logic/operations/OperationExecutionManager';
+  PhasedCommandRunner,
+  type IInitialRunPhasesOptions,
+  type IRunPhasesOptions
+} from './PhasedCommandRunner';
+import type { IOperationExecutionManagerOptions } from '../../logic/operations/OperationExecutionManager';
 import { RushConstants } from '../../logic/RushConstants';
 import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
 import type { RushConfigurationProject } from '../../api/RushConfigurationProject';
 import { BuildCacheConfiguration } from '../../api/BuildCacheConfiguration';
 import { SelectionParameterSet } from '../parsing/SelectionParameterSet';
 import type { IPhase, IPhasedCommandConfig } from '../../api/CommandLineConfiguration';
-import type { Operation } from '../../logic/operations/Operation';
 import type { OperationExecutionRecord } from '../../logic/operations/OperationExecutionRecord';
 import { associateParametersByPhase } from '../parsing/associateParametersByPhase';
 import { PhasedOperationPlugin } from '../../logic/operations/PhasedOperationPlugin';
 import { ShellOperationRunnerPlugin } from '../../logic/operations/ShellOperationRunnerPlugin';
 import { Event } from '../../api/EventHooks';
-import { ProjectChangeAnalyzer } from '../../logic/ProjectChangeAnalyzer';
-import { OperationStatus } from '../../logic/operations/OperationStatus';
-import type {
-  IExecutionResult,
-  IOperationExecutionResult
-} from '../../logic/operations/IOperationExecutionResult';
 import { OperationResultSummarizerPlugin } from '../../logic/operations/OperationResultSummarizerPlugin';
-import type { ITelemetryData, ITelemetryOperationResult } from '../../logic/Telemetry';
+import type { ITelemetryData } from '../../logic/Telemetry';
 import { parseParallelism } from '../parsing/ParseParallelism';
 import { CobuildConfiguration } from '../../api/CobuildConfiguration';
 import { CacheableOperationPlugin } from '../../logic/operations/CacheableOperationPlugin';
-import type { IInputsSnapshot, GetInputsSnapshotAsyncFn } from '../../logic/incremental/InputsSnapshot';
 import { RushProjectConfiguration } from '../../api/RushProjectConfiguration';
 import { LegacySkipPlugin } from '../../logic/operations/LegacySkipPlugin';
 import { ValidateOperationsPlugin } from '../../logic/operations/ValidateOperationsPlugin';
 import { ShardedPhasedOperationPlugin } from '../../logic/operations/ShardedPhaseOperationPlugin';
-import type { ProjectWatcher } from '../../logic/ProjectWatcher';
 import { FlagFile } from '../../api/FlagFile';
 import { WeightedOperationPlugin } from '../../logic/operations/WeightedOperationPlugin';
 import { getVariantAsync, VARIANT_PARAMETER } from '../../api/Variants';
@@ -85,46 +73,6 @@ export interface IPhasedScriptActionOptions extends IBaseScriptActionOptions<IPh
   watchDebounceMs: number | undefined;
 }
 
-interface IInitialRunPhasesOptions {
-  executionManagerOptions: Omit<
-    IOperationExecutionManagerOptions,
-    'beforeExecuteOperations' | 'inputsSnapshot'
-  >;
-  initialCreateOperationsContext: ICreateOperationsContext;
-  stopwatch: Stopwatch;
-  terminal: ITerminal;
-}
-
-interface IRunPhasesOptions extends IInitialRunPhasesOptions {
-  getInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined;
-  initialSnapshot: IInputsSnapshot | undefined;
-  executionManagerOptions: IOperationExecutionManagerOptions;
-}
-
-interface IExecuteOperationsOptions {
-  executeOperationsContext: IExecuteOperationsContext;
-  executionManagerOptions: IOperationExecutionManagerOptions;
-  ignoreHooks: boolean;
-  operations: Set<Operation>;
-  stopwatch: Stopwatch;
-  terminal: ITerminal;
-}
-
-interface IPhasedCommandTelemetry {
-  [key: string]: string | number | boolean;
-  isInitial: boolean;
-  isWatch: boolean;
-
-  countAll: number;
-  countSuccess: number;
-  countSuccessWithWarnings: number;
-  countFailure: number;
-  countBlocked: number;
-  countFromCache: number;
-  countSkipped: number;
-  countNoOp: number;
-}
-
 /**
  * This class implements phased commands which are run individually for each project in the repo,
  * possibly in parallel, and which may define multiple phases.
@@ -154,8 +102,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
   private readonly _alwaysInstall: boolean | undefined;
   private readonly _knownPhases: ReadonlyMap<string, IPhase>;
   private readonly _terminal: ITerminal;
-  private _changedProjectsOnly: boolean;
-  private _executionAbortController: AbortController | undefined;
 
   private readonly _changedProjectsOnlyParameter: CommandLineFlagParameter | undefined;
   private readonly _selectionParameters: SelectionParameterSet;
@@ -199,17 +145,7 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
     this._alwaysInstall = alwaysInstall;
     this._runsBeforeInstall = false;
     this._knownPhases = phases;
-    this._changedProjectsOnly = false;
     this.sessionAbortController = new AbortController();
-    this._executionAbortController = undefined;
-
-    this.sessionAbortController.signal.addEventListener(
-      'abort',
-      () => {
-        this._executionAbortController?.abort();
-      },
-      { once: true }
-    );
 
     this.hooks = new PhasedCommandHooks();
 
@@ -468,7 +404,6 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
     const isQuietMode: boolean = !this._verboseParameter.value;
 
     const changedProjectsOnly: boolean = !!this._changedProjectsOnlyParameter?.value;
-    this._changedProjectsOnly = changedProjectsOnly;
 
     let buildCacheConfiguration: BuildCacheConfiguration | undefined;
     let cobuildConfiguration: CobuildConfiguration | undefined;
@@ -623,8 +558,37 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
         terminal
       };
 
+      const changedProjectsOnlyParameter: CommandLineFlagParameter | undefined =
+        this._changedProjectsOnlyParameter;
+      const runner: PhasedCommandRunner = new PhasedCommandRunner({
+        actionName: this.actionName,
+        hooks: this.hooks,
+        rushConfiguration: this.rushConfiguration,
+        terminal,
+        isDebug: this.parser.isDebug,
+        sessionAbortController: this.sessionAbortController,
+        watchPhases: this._watchPhases,
+        watchDebounceMs: this._watchDebounceMs,
+        ipcEnabled: this._noIPCParameter?.value === false,
+        changedProjectsOnly,
+        changedProjectsOnlyParameterName: changedProjectsOnlyParameter
+          ? (changedProjectsOnlyParameter.scopedLongName ?? changedProjectsOnlyParameter.longName)
+          : undefined,
+        getTelemetryExtraData: () => ({
+          ...this._selectionParameters.getTelemetry(),
+          ...this.getParameterStringMap()
+        }),
+        logTelemetry: this.parser.telemetry
+          ? (entry: ITelemetryData) => {
+              this.parser.telemetry!.log(entry);
+              this.parser.flushTelemetry();
+            }
+          : undefined,
+        onAfterExecuteTask: () => this._doAfterTask()
+      });
+
       const internalOptions: IRunPhasesOptions = await measureAsyncFn(`${PERF_PREFIX}:runInitialPhases`, () =>
-        this._runInitialPhasesAsync(initialInternalOptions)
+        runner.runInitialPhasesAsync(initialInternalOptions)
       );
 
       if (isWatch) {
@@ -633,539 +597,13 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           buildCacheConfiguration.cacheWriteEnabled = false;
         }
 
-        await this._runWatchPhasesAsync(internalOptions);
+        await runner.runWatchPhasesAsync(internalOptions);
         terminal.writeDebugLine(`Watch mode exited.`);
       }
     } finally {
       if (cobuildConfiguration) {
         await cobuildConfiguration.destroyLockProviderAsync();
       }
-    }
-  }
-
-  private async _runInitialPhasesAsync(options: IInitialRunPhasesOptions): Promise<IRunPhasesOptions> {
-    const {
-      initialCreateOperationsContext,
-      executionManagerOptions: partialExecutionManagerOptions,
-      stopwatch,
-      terminal
-    } = options;
-
-    const { projectConfigurations } = initialCreateOperationsContext;
-    const { projectSelection } = initialCreateOperationsContext;
-
-    const operations: Set<Operation> = await measureAsyncFn(`${PERF_PREFIX}:createOperations`, () =>
-      this.hooks.createOperations.promise(new Set(), initialCreateOperationsContext)
-    );
-
-    const [getInputsSnapshotAsync, initialSnapshot] = await measureAsyncFn(
-      `${PERF_PREFIX}:analyzeRepoState`,
-      async () => {
-        terminal.write('Analyzing repo state... ');
-        const repoStateStopwatch: Stopwatch = new Stopwatch();
-        repoStateStopwatch.start();
-
-        const analyzer: ProjectChangeAnalyzer = new ProjectChangeAnalyzer(this.rushConfiguration);
-        const innerGetInputsSnapshotAsync: GetInputsSnapshotAsyncFn | undefined =
-          await analyzer._tryGetSnapshotProviderAsync(
-            projectConfigurations,
-            terminal,
-            // We need to include all dependencies, otherwise build cache id calculation will be incorrect
-            Selection.expandAllDependencies(projectSelection)
-          );
-        const innerInitialSnapshot: IInputsSnapshot | undefined = innerGetInputsSnapshotAsync
-          ? await innerGetInputsSnapshotAsync()
-          : undefined;
-
-        repoStateStopwatch.stop();
-        terminal.writeLine(`DONE (${repoStateStopwatch.toString()})`);
-        terminal.writeLine();
-        return [innerGetInputsSnapshotAsync, innerInitialSnapshot];
-      }
-    );
-
-    const abortController: AbortController = (this._executionAbortController = new AbortController());
-    const initialExecuteOperationsContext: IExecuteOperationsContext = {
-      ...initialCreateOperationsContext,
-      inputsSnapshot: initialSnapshot,
-      abortController
-    };
-
-    const executionManagerOptions: IOperationExecutionManagerOptions = {
-      ...partialExecutionManagerOptions,
-      inputsSnapshot: initialSnapshot,
-      beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
-        await measureAsyncFn(`${PERF_PREFIX}:beforeExecuteOperations`, () =>
-          this.hooks.beforeExecuteOperations.promise(records, initialExecuteOperationsContext)
-        );
-      }
-    };
-
-    const initialOptions: IExecuteOperationsOptions = {
-      executeOperationsContext: initialExecuteOperationsContext,
-      ignoreHooks: false,
-      operations,
-      stopwatch,
-      executionManagerOptions,
-      terminal
-    };
-
-    await measureAsyncFn(`${PERF_PREFIX}:executeOperations`, () =>
-      this._executeOperationsAsync(initialOptions)
-    );
-
-    return {
-      ...options,
-      executionManagerOptions,
-      getInputsSnapshotAsync,
-      initialSnapshot
-    };
-  }
-
-  private _registerWatchModeInterface(projectWatcher: ProjectWatcher): void {
-    const buildOnceKey: 'b' = 'b';
-    const changedProjectsOnlyKey: 'c' = 'c';
-    const invalidateKey: 'i' = 'i';
-    const quitKey: 'q' = 'q';
-    const abortKey: 'a' = 'a';
-    const toggleWatcherKey: 'w' = 'w';
-    const shutdownProcessesKey: 'x' = 'x';
-
-    const terminal: ITerminal = this._terminal;
-
-    projectWatcher.setPromptGenerator((isPaused: boolean) => {
-      const promptLines: string[] = [
-        `  Press <${quitKey}> to gracefully exit.`,
-        `  Press <${abortKey}> to abort queued operations. Any that have started will finish.`,
-        `  Press <${toggleWatcherKey}> to ${isPaused ? 'resume' : 'pause'}.`,
-        `  Press <${invalidateKey}> to invalidate all projects.`,
-        `  Press <${changedProjectsOnlyKey}> to ${
-          this._changedProjectsOnly ? 'disable' : 'enable'
-        } changed-projects-only mode (${this._changedProjectsOnly ? 'ENABLED' : 'DISABLED'}).`
-      ];
-      if (isPaused) {
-        promptLines.push(`  Press <${buildOnceKey}> to build once.`);
-      }
-      if (this._noIPCParameter?.value === false) {
-        promptLines.push(`  Press <${shutdownProcessesKey}> to reset child processes.`);
-      }
-      return promptLines;
-    });
-
-    const onKeyPress = (key: string): void => {
-      switch (key) {
-        case quitKey:
-          terminal.writeLine(`Exiting watch mode and aborting any scheduled work...`);
-          process.stdin.setRawMode(false);
-          process.stdin.off('data', onKeyPress);
-          process.stdin.unref();
-          this.sessionAbortController.abort();
-          break;
-        case abortKey:
-          terminal.writeLine(`Aborting current iteration...`);
-          this._executionAbortController?.abort();
-          break;
-        case toggleWatcherKey:
-          if (projectWatcher.isPaused) {
-            projectWatcher.resume();
-          } else {
-            projectWatcher.pause();
-          }
-          break;
-        case buildOnceKey:
-          if (projectWatcher.isPaused) {
-            projectWatcher.clearStatus();
-            terminal.writeLine(`Building once...`);
-            projectWatcher.resume();
-            projectWatcher.pause();
-          }
-          break;
-        case invalidateKey:
-          projectWatcher.clearStatus();
-          terminal.writeLine(`Invalidating all operations...`);
-          projectWatcher.invalidateAll('manual trigger');
-          if (!projectWatcher.isPaused) {
-            projectWatcher.resume();
-          }
-          break;
-        case changedProjectsOnlyKey:
-          this._changedProjectsOnly = !this._changedProjectsOnly;
-          projectWatcher.rerenderStatus();
-          break;
-        case shutdownProcessesKey:
-          projectWatcher.clearStatus();
-          terminal.writeLine(`Shutting down long-lived child processes...`);
-          // TODO: Inject this promise into the execution queue somewhere so that it gets waited on between runs
-          void this.hooks.shutdownAsync.promise();
-          break;
-        case '\u0003':
-          process.stdin.setRawMode(false);
-          process.stdin.off('data', onKeyPress);
-          process.stdin.unref();
-          this.sessionAbortController.abort();
-          process.kill(process.pid, 'SIGINT');
-          break;
-      }
-    };
-
-    process.stdin.setRawMode(true);
-    process.stdin.resume();
-    process.stdin.setEncoding('utf8');
-    process.stdin.on('data', onKeyPress);
-  }
-
-  /**
-   * Runs the command in watch mode. Fundamentally is a simple loop:
-   * 1) Wait for a change to one or more projects in the selection
-   * 2) Invoke the command on the changed projects, and, if applicable, impacted projects
-   *    Uses the same algorithm as --impacted-by
-   * 3) Goto (1)
-   */
-  private async _runWatchPhasesAsync(options: IRunPhasesOptions): Promise<void> {
-    const {
-      getInputsSnapshotAsync,
-      initialSnapshot,
-      initialCreateOperationsContext,
-      executionManagerOptions,
-      stopwatch,
-      terminal
-    } = options;
-
-    const phaseOriginal: Set<IPhase> = new Set(this._watchPhases);
-    const phaseSelection: Set<IPhase> = new Set(this._watchPhases);
-
-    const { projectSelection: projectsToWatch } = initialCreateOperationsContext;
-
-    if (!getInputsSnapshotAsync || !initialSnapshot) {
-      terminal.writeErrorLine(
-        `Cannot watch for changes if the Rush repo is not in a Git repository, exiting.`
-      );
-      throw new AlreadyReportedError();
-    }
-
-    // Use async import so that we don't pay the cost for sync builds
-    const { ProjectWatcher } = await import(
-      /* webpackChunkName: 'ProjectWatcher' */
-      '../../logic/ProjectWatcher'
-    );
-
-    const sessionAbortController: AbortController = this.sessionAbortController;
-    const abortSignal: AbortSignal = sessionAbortController.signal;
-
-    const projectWatcher: typeof ProjectWatcher.prototype = new ProjectWatcher({
-      getInputsSnapshotAsync,
-      initialSnapshot,
-      debounceMs: this._watchDebounceMs,
-      rushConfiguration: this.rushConfiguration,
-      projectsToWatch,
-      abortSignal,
-      terminal
-    });
-
-    // Ensure process.stdin allows interactivity before using TTY-only APIs
-    if (process.stdin.isTTY) {
-      this._registerWatchModeInterface(projectWatcher);
-    }
-
-    const onWaitingForChanges = (): void => {
-      // Allow plugins to display their own messages when waiting for changes.
-      this.hooks.waitingForChanges.call();
-
-      // Report so that the developer can always see that it is in watch mode as the latest console line.
-      terminal.writeLine(
-        `Watching for changes to ${projectsToWatch.size} ${
-          projectsToWatch.size === 1 ? 'project' : 'projects'
-        }. Press Ctrl+C to exit.`
-      );
-    };
-
-    function invalidateOperation(operation: Operation, reason: string): void {
-      const { associatedProject } = operation;
-      // Since ProjectWatcher only tracks entire projects, widen the operation to its project
-      // Revisit when migrating to @rushstack/operation-graph and we have a long-lived operation graph
-      projectWatcher.invalidateProject(associatedProject, `${operation.name!} (${reason})`);
-    }
-
-    // Loop until Ctrl+C
-    while (!abortSignal.aborted) {
-      // On the initial invocation, this promise will return immediately with the full set of projects
-      const { changedProjects, inputsSnapshot: state } = await measureAsyncFn(
-        `${PERF_PREFIX}:waitForChanges`,
-        () => projectWatcher.waitForChangeAsync(onWaitingForChanges)
-      );
-
-      if (abortSignal.aborted) {
-        return;
-      }
-
-      if (stopwatch.state === StopwatchState.Stopped) {
-        // Clear and reset the stopwatch so that we only report time from a single execution at a time
-        stopwatch.reset();
-        stopwatch.start();
-      }
-
-      terminal.writeLine(
-        `Detected changes in ${changedProjects.size} project${changedProjects.size === 1 ? '' : 's'}:`
-      );
-      const names: string[] = [...changedProjects].map((x) => x.packageName).sort();
-      for (const name of names) {
-        terminal.writeLine(`    ${Colorize.cyan(name)}`);
-      }
-
-      const initialAbortController: AbortController = (this._executionAbortController =
-        new AbortController());
-
-      // Account for consumer relationships
-      const executeOperationsContext: IExecuteOperationsContext = {
-        ...initialCreateOperationsContext,
-        abortController: initialAbortController,
-        changedProjectsOnly: !!this._changedProjectsOnly,
-        isInitial: false,
-        inputsSnapshot: state,
-        projectsInUnknownState: changedProjects,
-        phaseOriginal,
-        phaseSelection,
-        invalidateOperation
-      };
-
-      const operations: Set<Operation> = await measureAsyncFn(`${PERF_PREFIX}:createOperations`, () =>
-        this.hooks.createOperations.promise(new Set(), executeOperationsContext)
-      );
-
-      const executeOptions: IExecuteOperationsOptions = {
-        executeOperationsContext,
-        // For now, don't run pre-build or post-build in watch mode
-        ignoreHooks: true,
-        operations,
-        stopwatch,
-        executionManagerOptions: {
-          ...executionManagerOptions,
-          inputsSnapshot: state,
-          beforeExecuteOperationsAsync: async (records: Map<Operation, OperationExecutionRecord>) => {
-            await measureAsyncFn(`${PERF_PREFIX}:beforeExecuteOperations`, () =>
-              this.hooks.beforeExecuteOperations.promise(records, executeOperationsContext)
-            );
-          }
-        },
-        terminal
-      };
-
-      try {
-        // Delegate the the underlying command, for only the projects that need reprocessing
-        await measureAsyncFn(`${PERF_PREFIX}:executeOperations`, () =>
-          this._executeOperationsAsync(executeOptions)
-        );
-      } catch (err) {
-        // In watch mode, we want to rebuild even if the original build failed.
-        if (!(err instanceof AlreadyReportedError)) {
-          throw err;
-        }
-      }
-    }
-  }
-
-  /**
-   * Runs a set of operations and reports the results.
-   */
-  private async _executeOperationsAsync(options: IExecuteOperationsOptions): Promise<void> {
-    const {
-      executeOperationsContext,
-      executionManagerOptions,
-      ignoreHooks,
-      operations,
-      stopwatch,
-      terminal
-    } = options;
-
-    const executionManager: OperationExecutionManager = new OperationExecutionManager(
-      operations,
-      executionManagerOptions
-    );
-
-    const { isInitial, isWatch, abortController, invalidateOperation } = executeOperationsContext;
-
-    let success: boolean = false;
-    let result: IExecutionResult | undefined;
-
-    try {
-      const definiteResult: IExecutionResult = await measureAsyncFn(
-        `${PERF_PREFIX}:executeOperationsInner`,
-        () => executionManager.executeAsync(abortController)
-      );
-      success = definiteResult.status === OperationStatus.Success;
-      result = definiteResult;
-
-      await measureAsyncFn(`${PERF_PREFIX}:afterExecuteOperations`, () =>
-        this.hooks.afterExecuteOperations.promise(definiteResult, executeOperationsContext)
-      );
-
-      stopwatch.stop();
-
-      const message: string = `rush ${this.actionName} (${stopwatch.toString()})`;
-      if (result.status === OperationStatus.Success) {
-        terminal.writeLine(Colorize.green(message));
-      } else {
-        terminal.writeLine(message);
-      }
-    } catch (error) {
-      success = false;
-      stopwatch.stop();
-
-      if (error instanceof AlreadyReportedError) {
-        terminal.writeLine(`rush ${this.actionName} (${stopwatch.toString()})`);
-      } else {
-        if (error && (error as Error).message) {
-          if (this.parser.isDebug) {
-            terminal.writeErrorLine('Error: ' + (error as Error).stack);
-          } else {
-            terminal.writeErrorLine('Error: ' + (error as Error).message);
-          }
-        }
-
-        terminal.writeErrorLine(Colorize.red(`rush ${this.actionName} - Errors! (${stopwatch.toString()})`));
-      }
-    }
-
-    this._executionAbortController = undefined;
-
-    if (invalidateOperation) {
-      const operationResults: ReadonlyMap<Operation, IOperationExecutionResult> | undefined =
-        result?.operationResults;
-      if (operationResults) {
-        for (const [operation, { status }] of operationResults) {
-          if (status === OperationStatus.Aborted) {
-            invalidateOperation(operation, 'aborted');
-          }
-        }
-      }
-    }
-
-    if (!ignoreHooks) {
-      measureFn(`${PERF_PREFIX}:doAfterTask`, () => this._doAfterTask());
-    }
-
-    if (this.parser.telemetry) {
-      const logEntry: ITelemetryData = measureFn(`${PERF_PREFIX}:prepareTelemetry`, () => {
-        const jsonOperationResults: Record<string, ITelemetryOperationResult> = {};
-
-        const extraData: IPhasedCommandTelemetry = {
-          // Fields preserved across the command invocation
-          ...this._selectionParameters.getTelemetry(),
-          ...this.getParameterStringMap(),
-          isWatch,
-          // Fields specific to the current operation set
-          isInitial,
-
-          countAll: 0,
-          countSuccess: 0,
-          countSuccessWithWarnings: 0,
-          countFailure: 0,
-          countBlocked: 0,
-          countFromCache: 0,
-          countSkipped: 0,
-          countNoOp: 0
-        };
-
-        const { _changedProjectsOnlyParameter: changedProjectsOnlyParameter } = this;
-        if (changedProjectsOnlyParameter) {
-          // Overwrite this value since we allow changing it at runtime.
-          extraData[changedProjectsOnlyParameter.scopedLongName ?? changedProjectsOnlyParameter.longName] =
-            this._changedProjectsOnly;
-        }
-
-        if (result) {
-          const { operationResults } = result;
-
-          const nonSilentDependenciesByOperation: Map<Operation, Set<string>> = new Map();
-          function getNonSilentDependencies(operation: Operation): ReadonlySet<string> {
-            let realDependencies: Set<string> | undefined = nonSilentDependenciesByOperation.get(operation);
-            if (!realDependencies) {
-              realDependencies = new Set();
-              nonSilentDependenciesByOperation.set(operation, realDependencies);
-              for (const dependency of operation.dependencies) {
-                const dependencyRecord: IOperationExecutionResult | undefined =
-                  operationResults.get(dependency);
-                if (dependencyRecord?.silent) {
-                  for (const deepDependency of getNonSilentDependencies(dependency)) {
-                    realDependencies.add(deepDependency);
-                  }
-                } else {
-                  realDependencies.add(dependency.name!);
-                }
-              }
-            }
-            return realDependencies;
-          }
-
-          for (const [operation, operationResult] of operationResults) {
-            if (operationResult.silent) {
-              // Architectural operation. Ignore.
-              continue;
-            }
-
-            const { _operationMetadataManager: operationMetadataManager } =
-              operationResult as OperationExecutionRecord;
-
-            const { startTime, endTime } = operationResult.stopwatch;
-            jsonOperationResults[operation.name!] = {
-              startTimestampMs: startTime,
-              endTimestampMs: endTime,
-              nonCachedDurationMs: operationResult.nonCachedDurationMs,
-              wasExecutedOnThisMachine: operationMetadataManager?.wasCobuilt !== true,
-              result: operationResult.status,
-              dependencies: Array.from(getNonSilentDependencies(operation)).sort()
-            };
-
-            extraData.countAll++;
-            switch (operationResult.status) {
-              case OperationStatus.Success:
-                extraData.countSuccess++;
-                break;
-              case OperationStatus.SuccessWithWarning:
-                extraData.countSuccessWithWarnings++;
-                break;
-              case OperationStatus.Failure:
-                extraData.countFailure++;
-                break;
-              case OperationStatus.Blocked:
-                extraData.countBlocked++;
-                break;
-              case OperationStatus.FromCache:
-                extraData.countFromCache++;
-                break;
-              case OperationStatus.Skipped:
-                extraData.countSkipped++;
-                break;
-              case OperationStatus.NoOp:
-                extraData.countNoOp++;
-                break;
-              default:
-                // Do nothing.
-                break;
-            }
-          }
-        }
-
-        const innerLogEntry: ITelemetryData = {
-          name: this.actionName,
-          durationInSeconds: stopwatch.duration,
-          result: success ? 'Succeeded' : 'Failed',
-          extraData,
-          operationResults: jsonOperationResults
-        };
-
-        return innerLogEntry;
-      });
-
-      measureFn(`${PERF_PREFIX}:beforeLog`, () => this.hooks.beforeLog.call(logEntry));
-
-      this.parser.telemetry.log(logEntry);
-
-      this.parser.flushTelemetry();
-    }
-
-    if (!success && !isWatch) {
-      throw new AlreadyReportedError();
     }
   }
 

--- a/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
+++ b/libraries/rush-lib/src/cli/scriptActions/PhasedScriptAction.ts
@@ -21,6 +21,7 @@ import {
   type IInitialRunPhasesOptions,
   type IRunPhasesOptions
 } from './PhasedCommandRunner';
+import type { DaemonControlServer } from './DaemonControlServer';
 import type { IOperationExecutionManagerOptions } from '../../logic/operations/OperationExecutionManager';
 import { RushConstants } from '../../logic/RushConstants';
 import { EnvironmentVariableNames } from '../../api/EnvironmentConfiguration';
@@ -597,7 +598,29 @@ export class PhasedScriptAction extends BaseScriptAction<IPhasedCommandConfig> i
           buildCacheConfiguration.cacheWriteEnabled = false;
         }
 
-        await runner.runWatchPhasesAsync(internalOptions);
+        // EXPERIMENTAL (rush daemon prototype): when RUSHMCP_DAEMON_SOCKET is set, expose an in-process
+        // control channel so this long-lived watch process can also run Rush commands under the single
+        // repository lock it already holds. Slated to become a first-class "rush daemon" action.
+        // eslint-disable-next-line dot-notation
+        const daemonSocketPath: string | undefined = process.env['RUSHMCP_DAEMON_SOCKET'];
+        let daemonControlServer: DaemonControlServer | undefined;
+        if (daemonSocketPath) {
+          const { DaemonControlServer } = await import(
+            /* webpackChunkName: 'DaemonControlServer' */ './DaemonControlServer'
+          );
+          daemonControlServer = new DaemonControlServer({
+            socketPath: daemonSocketPath,
+            rushConfiguration: this.rushConfiguration,
+            terminal
+          });
+          daemonControlServer.start();
+        }
+
+        try {
+          await runner.runWatchPhasesAsync(internalOptions);
+        } finally {
+          daemonControlServer?.close();
+        }
         terminal.writeDebugLine(`Watch mode exited.`);
       }
     } finally {


### PR DESCRIPTION
## Summary

The **rush-lib half** of the in-process `rush daemon` (Path 2): a long-lived process can hold the repo lock once and run the watch **and** commands in-process — no child `rush start`, no lock fights.

### What's here
- **`PhasedCommandRunner`** extracted from the 1196-line `PhasedScriptAction` (the action injects CLI glue — telemetry, event hooks — via callbacks; the runner is reusable by a long-lived host). `PhasedScriptAction` drops to ~480 lines.
- **`DaemonControlServer`** — an experimental, env-gated (`RUSHMCP_DAEMON_SOCKET`) unix-socket control channel on the watch: `status`, `check`, `install`.
- **`runExclusiveAsync`** — pause the watch → abort + await the in-flight build → stop IPC workers (shutdownAsync hook) → run the command → resume. In-process `install` runs under the lock the watch already holds.
- **Command queue** — control commands serialize, so concurrent agents can't run overlapping commands.

### Validation
rush-lib `heft test` **627/0** (== pre-change baseline) at every step; local-rush regression (`rush build`, `rush start --watch`); and over the control socket, `install` ran in-process **while watching** ("Install completed."; daemon log `[PAUSED] → install → [WATCHING] resuming`; never "Another Rush command is already running"); the watch resumed and rebuilt on a fresh change; two concurrent installs serialized.

### Notes
- Env-gated and marked **experimental** — the seam for a future first-class `RushDaemonAction`.
- `@microsoft/rush-lib` is published → a `rush change` entry is needed before upstreaming (deferred).
- Independent of the MCP feature PR (#20) — disjoint files (`libraries/rush-lib/*` vs `apps/rush-mcp-server/*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
